### PR TITLE
fix: update to work with latest ansible 2.9

### DIFF
--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -38,7 +38,6 @@
       role: "{{ playbook_dir }}/../../../../roles/ansible-ca-store"
       certificate: "{{ ca_certificate }}"
       certificate_rename: "ca.crt"
-    become: yes
     when: ca_certificate != ""
   - name: Install Vault PKI CA Certificate
     include_role:

--- a/roles/vault-pki/tasks/main.yml
+++ b/roles/vault-pki/tasks/main.yml
@@ -55,7 +55,7 @@
         msg: "Failed to download the CA from all the URLs. Make sure they are accessible from your machine."
       when: first_working is not defined
     - name: Install certificate to OS store
-      include_tasks: "{{ role_path }}/../../tasks/include_role_checked.yml"
+      import_tasks: "{{ role_path }}/../../tasks/include_role_checked.yml"
       vars:
         role: "{{ role_path }}/../ansible-ca-store"
         certificate: "{{ download_temp.path }}"


### PR DESCRIPTION
This is needed to run `packer` with ansible 2.9. May need to
check if it is backward compatible. Issue discovered while 
working on dsaidgovsg/l-cloud#395.