### PR TITLE
refactor:  fluentd-pre module and packer

### DIFF
--- a/modules/core/packer/consul/site.yml
+++ b/modules/core/packer/consul/site.yml
@@ -16,6 +16,7 @@
     consul_scheme: https
     consul_token: ""
     consul_integration_prefix: "terraform/"
+    for_fluentd_server: "no"
     timezone: "Asia/Singapore"
   tasks:
   - name: Upgrade all packages to the latest version

--- a/modules/core/packer/nomad_clients/site.yml
+++ b/modules/core/packer/nomad_clients/site.yml
@@ -25,6 +25,7 @@
     nomad_additional_config: []
     netshare_version: 0.36
     docker_enable_efs: false
+    for_fluentd_server: "no"
     timezone: "Asia/Singapore"
   tasks:
   - name: Upgrade all packages to the latest version

--- a/modules/core/packer/nomad_servers/site.yml
+++ b/modules/core/packer/nomad_servers/site.yml
@@ -22,6 +22,7 @@
     consul_token: ""
     consul_integration_prefix: "terraform/"
     nomad_additional_config: []
+    for_fluentd_server: "no"
     timezone: "Asia/Singapore"
   pre_tasks:
   - name: Upgrade all packages to the latest version

--- a/modules/core/packer/vault/site.yml
+++ b/modules/core/packer/vault/site.yml
@@ -23,6 +23,7 @@
     consul_scheme: https
     consul_token: ""
     consul_integration_prefix: "terraform/"
+    for_fluentd_server: "no"
     timezone: "Asia/Singapore"
   tasks:
   - name: Upgrade all packages to the latest version

--- a/modules/elasticsearch/INOUT.md
+++ b/modules/elasticsearch/INOUT.md
@@ -3,7 +3,6 @@
 | Name | Version |
 |------|---------|
 | aws | >= 2.7 |
-| consul | >= 2.5 |
 
 ## Inputs
 
@@ -30,7 +29,6 @@
 | es\_access\_cidr\_block | Elasticsearch access CIDR block to allow access | `list(string)` | n/a | yes |
 | es\_additional\_tags | Additional tags to apply on Elasticsearch | `map(string)` | `{}` | no |
 | es\_base\_domain | Base domain for Elasticsearch cluster | `string` | n/a | yes |
-| es\_consul\_service | Name to register in consul to identify Elasticsearch service | `string` | `"elasticsearch"` | no |
 | es\_dedicated\_master\_enabled | Enable dedicated master nodes for Elasticsearch | `bool` | n/a | yes |
 | es\_default\_access | Rest API / Web UI access | `map(any)` | <pre>{<br>  "port": 443,<br>  "protocol": "tcp",<br>  "type": "ingress"<br>}<br></pre> | no |
 | es\_domain\_name | Elasticsearch domain name | `string` | n/a | yes |
@@ -77,8 +75,6 @@
 | kms\_key\_inaccessible\_evaluation\_periods | Number of periods to evaluate for the alarm. | `string` | `"1"` | no |
 | kms\_key\_inaccessible\_period | Duration in seconds to evaluate for the alarm. | `string` | `"60"` | no |
 | kms\_key\_inaccessible\_threshold | Threshold for the number of kms key inaccessible error | `string` | `"1"` | no |
-| lb\_cname | DNS CNAME for the Load balancer | `string` | `""` | no |
-| lb\_zone\_id | Zone ID for the Load balancer DNS CNAME | `string` | `""` | no |
 | low\_storage\_space\_enable | Whether to enable alarm | `bool` | `false` | no |
 | low\_storage\_space\_evaluation\_periods | Number of periods to evaluate for the alarm. | `string` | `"1"` | no |
 | low\_storage\_space\_name | Name of the alarm | `string` | `"low_storage_space_alarm"` | no |
@@ -88,10 +84,6 @@
 | node\_unreachable\_evaluation\_periods | Number of periods to evaluate for the alarm. | `string` | `"1"` | no |
 | node\_unreachable\_period | Duration in seconds to evaluate for the alarm. | `string` | `"86400"` | no |
 | ok\_actions | A list of ARNs (i.e. SNS Topic ARN) to notify for ok action | `list(string)` | `[]` | no |
-| redirect\_domain | Domain name to redirect | `string` | `""` | no |
-| redirect\_listener\_arn | LB listener ARN to attach the rule to | `string` | `""` | no |
-| redirect\_route53\_zone\_id | Route53 Zone ID to create the Redirect Record in | `string` | `""` | no |
-| redirect\_rule\_priority | Rule priority for redirect | `number` | `100` | no |
 | security\_group\_additional\_tags | Additional tags to apply on the security group | `map(string)` | `{}` | no |
 | security\_group\_name | Name of security group, leaving this empty generates a group name | `string` | n/a | yes |
 | security\_group\_vpc\_id | VPC ID to apply on the security group | `string` | n/a | yes |
@@ -103,7 +95,6 @@
 | snapshot\_failed\_evaluation\_periods | Number of periods to evaluate for the alarm. | `string` | `"1"` | no |
 | snapshot\_failed\_period | Duration in seconds to evaluate for the alarm. | `string` | `"60"` | no |
 | snapshot\_failed\_threshold | Threshold for the number of snapshot failed | `string` | `"1"` | no |
-| use\_redirect | Indicates whether to use redirect users | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -1,17 +1,8 @@
 # AWS Elasticsearch module
 
-This modules creates an Elasticsearch cluster in a domain, with (optional) redirection
-service to allow easy access to Kibana web interface.
-
-## Registered `consul` service name
-
-The registered `consul` service name is `elasticsearch`, and the default port
-used is `443`.
-
-The actual VPC service and port are registered in `consul`. Any other services
-that require Elasticsearch service should always use the actual VPC service
-name, since the service is hosted under SSL and the SSL certificate to accept is
-registered under the VPC name (and not the `consul` service name).
+This modules creates an Elasticsearch cluster in a domain without Consul service discovery
+or redirection to Kibana. This module should be run before Core and Fluentd so that
+Fluentd can send logs to Elasticsearch.
 
 ## Default Access Policy
 
@@ -33,19 +24,6 @@ the Terraform module, you will have to manually configure Elasticsearch to log s
 See the
 [instructions](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-slow-logs-indices)
 for how to do so.
-
-## Redirection
-
-The module can optionally setup an ELB listener rule to redirect users to the Kibana interface
-using a much friendlier URL.
-
-We recommend that you use the internal ELB that was created by the `Core` module. For example, the
-list below will list the pairs of variables in this module that can use the output from the `Core`
-module:
-
-- `var.lb_cname`: `module.core.internal_lb_dns_name`
-- `var.lb_zone_id`: `module.core.internal_lb_zone_id`
-- `var.redirect_listener_arn`: `module.core.internal_lb_https_listener_arn`
 
 ## Service Linked Role
 
@@ -92,15 +70,6 @@ module "es" {
 
   enable_slow_index_log = true
   slow_index_log_name   = "my-cloud-es-slow-index"
-
-  # Optional section for redirecting users to the unfriendly Kibana URL
-
-  use_redirect             = true
-  redirect_route53_zone_id = "xxx"
-  redirect_domain          = "kibana.xxx.xxx"
-  lb_cname                 = "${module.core.internal_lb_dns_name}"
-  lb_zone_id               = "${module.core.internal_lb_zone_id}"
-  redirect_listener_arn    = "${module.core.internal_lb_https_listener_arn}"
 }
 ```
 

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -86,11 +86,6 @@ variable "es_default_access" {
   }
 }
 
-variable "es_consul_service" {
-  description = "Name to register in consul to identify Elasticsearch service"
-  default     = "elasticsearch"
-}
-
 variable "es_version" {
   # Available versions: https://aws.amazon.com/elasticsearch-service/faqs/
   # Currently cannot use 6.X due to fluentd elasticsearch plugin output multiple type issue
@@ -160,45 +155,6 @@ variable "slow_index_additional_tags" {
 variable "slow_index_log_retention" {
   description = "Number of days to retain logs for."
   default     = "120"
-}
-
-#
-# Redirect related
-#
-
-variable "use_redirect" {
-  description = "Indicates whether to use redirect users "
-  default     = false
-}
-
-variable "redirect_route53_zone_id" {
-  description = "Route53 Zone ID to create the Redirect Record in"
-  default     = ""
-}
-
-variable "redirect_domain" {
-  description = "Domain name to redirect"
-  default     = ""
-}
-
-variable "lb_cname" {
-  description = "DNS CNAME for the Load balancer"
-  default     = ""
-}
-
-variable "lb_zone_id" {
-  description = "Zone ID for the Load balancer DNS CNAME"
-  default     = ""
-}
-
-variable "redirect_listener_arn" {
-  description = "LB listener ARN to attach the rule to"
-  default     = ""
-}
-
-variable "redirect_rule_priority" {
-  description = "Rule priority for redirect"
-  default     = 100
 }
 
 #

--- a/modules/elasticsearch/versions.tf
+++ b/modules/elasticsearch/versions.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-    aws    = ">= 2.7"
-    consul = ">= 2.5"
+    aws = ">= 2.7"
   }
 }

--- a/modules/elasticsearch_post/INOUT.md
+++ b/modules/elasticsearch_post/INOUT.md
@@ -1,0 +1,28 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| consul | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| es\_consul\_service | Name to register in consul to identify Elasticsearch service | `string` | `"elasticsearch"` | no |
+| es\_default\_access | Rest API / Web UI access | `map(any)` | <pre>{<br>  "port": 443,<br>  "protocol": "tcp",<br>  "type": "ingress"<br>}<br></pre> | no |
+| es\_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests | `any` | n/a | yes |
+| es\_post\_access\_cidr\_block | Elasticsearch access CIDR block to allow access | `list(string)` | n/a | yes |
+| es\_security\_group\_id | ID of the Security Group attached to Elasticsearch | `any` | n/a | yes |
+| lb\_cname | DNS CNAME for the Load balancer | `string` | `""` | no |
+| lb\_zone\_id | Zone ID for the Load balancer DNS CNAME | `string` | `""` | no |
+| redirect\_domain | Domain name to redirect | `string` | `""` | no |
+| redirect\_listener\_arn | LB listener ARN to attach the rule to | `string` | `""` | no |
+| redirect\_route53\_zone\_id | Route53 Zone ID to create the Redirect Record in | `string` | `""` | no |
+| redirect\_rule\_priority | Rule priority for redirect | `number` | `100` | no |
+| use\_redirect | Indicates whether to use redirect users | `bool` | `false` | no |
+
+## Outputs
+
+No output.
+

--- a/modules/elasticsearch_post/README.md
+++ b/modules/elasticsearch_post/README.md
@@ -1,0 +1,32 @@
+# AWS Elasticsearch-post module
+
+This module provides the additional Consul registration and redirection to Kibana to
+an already running Elasticsearch module. This should be run only after Elasticsearch
+and Core are up.
+
+## Registered `consul` service name
+
+The registered `consul` service name is `elasticsearch`, and the default port
+used is `443`.
+
+The actual VPC service and port are registered in `consul`. Any other services
+that require Elasticsearch service should always use the actual VPC service
+name, since the service is hosted under SSL and the SSL certificate to accept is
+registered under the VPC name (and not the `consul` service name).
+
+## Redirection
+
+The module can optionally setup an ELB listener rule to redirect users to the Kibana interface
+using a much friendlier URL.
+
+We recommend that you use the internal ELB that was created by the `Core` module. For example, the
+list below will list the pairs of variables in this module that can use the output from the `Core`
+module:
+
+- `var.lb_cname`: `module.core.internal_lb_dns_name`
+- `var.lb_zone_id`: `module.core.internal_lb_zone_id`
+- `var.redirect_listener_arn`: `module.core.internal_lb_https_listener_arn`
+
+## Inputs and Outputs
+
+Refer to [INOUT.md](INOUT.md)

--- a/modules/elasticsearch_post/consul.tf
+++ b/modules/elasticsearch_post/consul.tf
@@ -1,6 +1,6 @@
 resource "consul_node" "es" {
   name    = var.es_consul_service
-  address = local.endpoint
+  address = var.es_endpoint
 }
 
 resource "consul_service" "es" {

--- a/modules/elasticsearch_post/main.tf
+++ b/modules/elasticsearch_post/main.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group_rule" "es_post_access_rule" {
+  type              = var.es_default_access["type"]
+  from_port         = var.es_default_access["port"]
+  to_port           = var.es_default_access["port"]
+  protocol          = var.es_default_access["protocol"]
+  cidr_blocks       = var.es_post_access_cidr_block
+  security_group_id = var.es_security_group_id
+}

--- a/modules/elasticsearch_post/redirect.tf
+++ b/modules/elasticsearch_post/redirect.tf
@@ -23,7 +23,7 @@ resource "aws_lb_listener_rule" "redirect" {
     type = "redirect"
 
     redirect {
-      host        = local.endpoint
+      host        = var.es_endpoint
       path        = "/_plugin/kibana/#{path}"
       port        = 443
       protocol    = "HTTPS"

--- a/modules/elasticsearch_post/variables.tf
+++ b/modules/elasticsearch_post/variables.tf
@@ -1,0 +1,75 @@
+#
+# Consul related
+#
+
+variable "es_consul_service" {
+  description = "Name to register in consul to identify Elasticsearch service"
+  default     = "elasticsearch"
+}
+
+#
+# ES access
+#
+
+variable "es_endpoint" {
+  description = "Domain-specific endpoint used to submit index, search, and data upload requests"
+}
+
+variable "es_default_access" {
+  description = "Rest API / Web UI access"
+  type        = map(any)
+
+  default = {
+    type     = "ingress"
+    protocol = "tcp"
+    port     = 443
+  }
+}
+
+variable "es_post_access_cidr_block" {
+  description = "Elasticsearch access CIDR block to allow access"
+  type        = list(string)
+}
+
+variable "es_security_group_id" {
+  description = "ID of the Security Group attached to Elasticsearch"
+}
+
+#
+# Redirect related
+#
+
+variable "use_redirect" {
+  description = "Indicates whether to use redirect users "
+  default     = false
+}
+
+variable "redirect_route53_zone_id" {
+  description = "Route53 Zone ID to create the Redirect Record in"
+  default     = ""
+}
+
+variable "redirect_domain" {
+  description = "Domain name to redirect"
+  default     = ""
+}
+
+variable "lb_cname" {
+  description = "DNS CNAME for the Load balancer"
+  default     = ""
+}
+
+variable "lb_zone_id" {
+  description = "Zone ID for the Load balancer DNS CNAME"
+  default     = ""
+}
+
+variable "redirect_listener_arn" {
+  description = "LB listener ARN to attach the rule to"
+  default     = ""
+}
+
+variable "redirect_rule_priority" {
+  description = "Rule priority for redirect"
+  default     = 100
+}

--- a/modules/fluentd_pre/INOUT.md
+++ b/modules/fluentd_pre/INOUT.md
@@ -1,0 +1,29 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| local | n/a |
+| template | ~> 2.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| artifacts\_base\_path | Base path to output file artifacts. Use `get_terragrunt_dir()` with an `extra_argument` to provide this value | `string` | `"./"` | no |
+| consul\_key\_prefix | Path prefix to the key in Consul to set for the `core` module to know that this module has<br>        been applied. If you change this, you have to update the<br>        `integration_consul_prefix` variable in the core module as well. | `string` | `"terraform/"` | no |
+| elasticsearch\_host | Elasticsearch endpoint used to submit index, search, and data upload requests | `any` | n/a | yes |
+| elasticsearch\_port | Elasticsearch service port | `any` | n/a | yes |
+| logs\_s3\_abort\_incomplete\_days | Specifies the number of days after initiating a multipart upload when the multipart upload must be completed. | `number` | `7` | no |
+| logs\_s3\_bucket\_name | Name of S3 bucket to store logs for long term archival | `string` | `""` | no |
+| logs\_s3\_enabled | Enable to log to S3 | `bool` | `true` | no |
+| logs\_s3\_glacier\_transition\_days | Number of days before logs are transitioned to IA. Must be > var.logs\_s3\_ia\_transition\_days + 30 days | `number` | `365` | no |
+| logs\_s3\_ia\_transition\_days | Number of days before logs are transitioned to IA. Must be > 30 days | `number` | `90` | no |
+| logs\_s3\_policy | Name of the IAM policy to provision for write access to the bucket | `string` | `"LogsS3Write_New"` | no |
+| logs\_s3\_storage\_class | Default storage class to store logs in S3. Choose from `STANDARD`, `REDUCED_REDUNDANCY` or `STANDARD_IA` | `string` | `"STANDARD"` | no |
+| tags | Tags to apply to resources | `map` | <pre>{<br>  "Terraform": "true"<br>}<br></pre> | no |
+
+## Outputs
+
+No output.
+

--- a/modules/fluentd_pre/README.md
+++ b/modules/fluentd_pre/README.md
@@ -1,0 +1,18 @@
+# Fluentd Server
+
+This module sets up a Fluentd server which forwards logs from other modules to S3 and 
+Elasticsearch.
+
+## Packer Template
+
+### Instance AMI
+
+You will have to build an AMI with the [Packer template](packer/packer.json) provided.
+
+```bash
+packer build \
+    -var-file "your_vars.json" \
+    packer/ami/packer.json
+```
+
+Ansible will be used to provision the AMI.

--- a/modules/fluentd_pre/main.tf
+++ b/modules/fluentd_pre/main.tf
@@ -1,0 +1,44 @@
+provider "template" {
+  # See: https://github.com/terraform-providers/terraform-provider-template/blob/v2.0.0/CHANGELOG.md#200-january-14-2019
+  # Need to pin the minimum version for templates/fluent.conf
+  version = "~> 2.0"
+}
+
+locals {
+  file_logging_consul_key  = "${var.consul_key_prefix}fluentd/log_to_file"
+  fluentd_match_consul_key = "${var.consul_key_prefix}fluentd/match"
+  s3_consul_key            = "${var.consul_key_prefix}fluentd/log_to_s3"
+  inject_source_host       = "${var.consul_key_prefix}fluentd/inject_source_host"
+  source_address_key       = "${var.consul_key_prefix}fluentd/source_address_key"
+  source_hostname_key      = "${var.consul_key_prefix}fluentd/source_hostname_key"
+}
+
+data "template_file" "fluentd_conf" {
+  template = file("${path.module}/templates/fluent.conf")
+
+  vars = {
+    elasticsearch_host = var.elasticsearch_host
+    elasticsearch_port = var.elasticsearch_port
+
+    fluentd_port = 4224
+    es6_support  = false
+
+    s3_bucket     = aws_s3_bucket.logs[0].id
+    s3_region     = "ap-southeast-1"
+    s3_prefix     = "logs/"
+    storage_class = var.logs_s3_storage_class
+
+    file_logging_consul_key  = local.file_logging_consul_key
+    fluentd_match_consul_key = local.fluentd_match_consul_key
+    s3_consul_key            = local.s3_consul_key
+
+    inject_source_host  = local.inject_source_host
+    source_address_key  = local.source_address_key
+    source_hostname_key = local.source_hostname_key
+  }
+}
+
+resource "local_file" "fluentd_rendered_conf" {
+  content  = data.template_file.fluentd_conf.rendered
+  filename = "${var.artifacts_base_path}/rendered/fluent.conf"
+}

--- a/modules/fluentd_pre/packer/packer.json
+++ b/modules/fluentd_pre/packer/packer.json
@@ -1,0 +1,91 @@
+{
+  "min_packer_version": "1.4.0",
+  "variables": {
+    "additional_ntp_servers": "[\"169.254.169.123\"]",
+    "ami_base_name": "fluentd",
+    "aws_region": "ap-southeast-1",
+    "subnet_id": "",
+    "temporary_security_group_source_cidrs": "0.0.0.0/0",
+    "associate_public_ip_address": "true",
+    "ssh_interface": "",
+    "td_agent_config_file": "",
+    "td_agent_config_vars_file": "",
+    "ca_certificate": "",
+    "for_fluentd_server": "yes",
+    "fluentd_server_config_file": "",
+    "timezone": "Asia/Singapore"
+  },
+  "builders": [
+    {
+      "name": "ubuntu-1604-fluentd-ami",
+      "ami_name": "{{ user `ami_base_name` }}-{{isotime | clean_resource_name}}",
+      "ami_description": "An Ubuntu 16.04 AMI that has Fluentd installed.",
+      "instance_type": "t3.micro",
+      "region": "{{user `aws_region`}}",
+      "type": "amazon-ebs",
+      "subnet_id": "{{user `subnet_id`}}",
+      "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
+      "ssh_interface": "{{user `ssh_interface`}}",
+      "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "architecture": "x86_64",
+          "name": "*ubuntu-xenial-16.04-amd64-server-*",
+          "block-device-mapping.volume-type": "gp2",
+          "root-device-type": "ebs"
+        },
+        "owners": [
+          "099720109477"
+        ],
+        "most_recent": true
+      },
+      "ssh_username": "ubuntu",
+      "run_tags": {
+        "Name": "{{user `ami_base_name` }}-{{isotime | clean_resource_name}}",
+        "Base Name": "{{user `ami_base_name` }}",
+        "Timestamp": "{{isotime \"2006-01-02 03:04:05\"}}",
+        "Packer": "yes"
+      },
+      "tags": {
+        "Name": "{{user `ami_base_name` }}-{{isotime | clean_resource_name}}",
+        "Base Name": "{{user `ami_base_name` }}",
+        "Timestamp": "{{isotime \"2006-01-02 03:04:05\"}}",
+        "Packer": "yes"
+      },
+      "snapshot_tags": {
+        "Name": "{{user `ami_base_name` }}-{{isotime | clean_resource_name}}",
+        "Base Name": "{{user `ami_base_name` }}",
+        "Timestamp": "{{isotime \"2006-01-02 03:04:05\"}}",
+        "Packer": "yes"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "timeout 60s bash -c \"while ! [ -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting on cloud-init...'; sleep 2; done\""
+      ]
+    },
+    {
+      "type": "ansible",
+      "playbook_file": "{{ template_dir }}/site.yml",
+      "user": "ubuntu",
+      "extra_arguments": [
+        "-e",
+        "{ \"additional_ntp_servers\": {{user `additional_ntp_servers`}} }",
+        "-e",
+        "td_agent_config_file={{user `td_agent_config_file`}} td_agent_config_vars_file={{user `td_agent_config_vars_file`}}",
+        "-e",
+        "ca_certificate={{user `ca_certificate`}}",
+        "-e",
+        "netshare_version={{user `netshare_version`}} docker_enable_efs={{user `docker_enable_efs`}}",
+        "-e",
+        "timezone={{user `timezone`}}",
+        "-e",
+        "ansible_python_interpreter=\"$(command -v python3)\""
+      ]
+    }
+  ]
+}

--- a/modules/fluentd_pre/packer/site.yml
+++ b/modules/fluentd_pre/packer/site.yml
@@ -1,0 +1,49 @@
+---
+- name: Provision AMI
+  hosts: all
+  vars:
+    additional_ntp_servers: ["169.254.169.123"]
+    docker_version: "17.11.0~ce-0~ubuntu"
+    ca_certificate: ""
+    td_agent_config_file: ""
+    td_agent_config_vars_file: ""
+    td_agent_config_dest_file: "/etc/td-agent/td-agent.conf"
+    for_fluentd_server: "yes"
+    fluentd_server_config_file: ""
+    timezone: "Asia/Singapore"
+  tasks:
+  - name: Upgrade all packages to the latest version
+    apt:
+      upgrade: yes
+      update_cache: yes
+    become: yes
+  - name: Install CA Certificate
+    include_tasks: "{{ playbook_dir }}/../../../tasks/include_role_checked.yml"
+    vars:
+      role: "{{ playbook_dir }}/../../../roles/ansible-ca-store"
+      certificate: "{{ ca_certificate }}"
+      certificate_rename: "ca.crt"
+    become: yes
+    when: ca_certificate != ""
+  - name: Install td-agent
+    include_role:
+      name: "{{ playbook_dir }}/../../../roles/td-agent"
+    vars:
+      config_file: "{{ td_agent_config_file }}"
+      config_vars_file: "{{ td_agent_config_vars_file }}"
+      config_dest_file: "{{ td_agent_config_dest_file }}"
+  - name: Install Vault PKI CA Certificate
+    include_role:
+      name: "{{ playbook_dir }}/../../../roles/vault-pki"
+  - name: Install chrony
+    include_role:
+      name: "{{ playbook_dir }}/../../../roles/chrony"
+  - name: Install Telegraf
+    include_role:
+      name: "{{ playbook_dir }}/../../../roles/telegraf"
+  - name: Install Vault SSH Configuration Script
+    include_role:
+      name: "{{ playbook_dir }}/../../../roles/install-ssh-script"
+  - name: Set default timezone
+    include_role:
+      name: "{{ playbook_dir }}/../../../roles/timezone"

--- a/modules/fluentd_pre/s3.tf
+++ b/modules/fluentd_pre/s3.tf
@@ -1,0 +1,77 @@
+# S3 bucket for logs long term retention
+resource "aws_s3_bucket" "logs" {
+  count = var.logs_s3_enabled ? 1 : 0
+
+  bucket = var.logs_s3_bucket_name
+  tags   = var.tags
+
+  force_destroy = false
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "LogArchivalTransition"
+    enabled = true
+
+    abort_incomplete_multipart_upload_days = var.logs_s3_abort_incomplete_days
+
+    transition {
+      days          = var.logs_s3_ia_transition_days
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = var.logs_s3_glacier_transition_days
+      storage_class = "GLACIER"
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+data "aws_iam_policy_document" "logs_s3_new" {
+  count = var.logs_s3_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.logs[0].arn}",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.logs[0].arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "logs_s3_new" {
+  count = var.logs_s3_enabled ? 1 : 0
+
+  name        = var.logs_s3_policy
+  path        = "/"
+  description = "IAM Policy to store logs in the archival S3 bucket"
+
+  policy = data.aws_iam_policy_document.logs_s3_new[0].json
+}

--- a/modules/fluentd_pre/templates/fluent.conf
+++ b/modules/fluentd_pre/templates/fluent.conf
@@ -1,0 +1,99 @@
+<source>
+  @type forward
+  port ${fluentd_port}
+</source>
+
+@include /config/secrets/*.conf
+@include /config/additional/*.conf
+
+<match fluentd.tcp>
+  @type copy
+  
+  {{ if eq (keyOrDefault "${file_logging_consul_key}" "false") "true" }}
+  <store ignore_error>
+    @type file
+
+    path /fluentd/logs/$${tag}-%Y%m%d
+    append true
+
+    <buffer tag, time>
+      flush_at_shutdown true
+      flush_mode interval
+      flush_interval 5s
+      retry_forever true
+      retry_max_interval 128s
+      timekey_use_utc false
+    </buffer>
+  </store>
+  {{ end }}
+
+  {{ if eq (keyOrDefault "${s3_consul_key}" "false") "true" }}
+  <store>
+    @type s3
+
+    aws_key_id "#{ENV['AWS_ACCESS_KEY_ID']}"
+    aws_sec_key "#{ENV['AWS_SECRET_ACCESS_KEY']}"
+
+    s3_bucket "${s3_bucket}"
+    s3_region "${s3_region}"
+
+    path "${s3_prefix}%Y/%m/%d/%H/$${tag}/"
+    s3_object_key_format "%%{path}%%{time_slice}_%%{hex_random}_%%{index}.%%{file_extension}"
+    buffer_path "buffer/"
+    storage_class "${storage_class}"
+
+    auto_create_bucket false
+    check_bucket true
+
+    <buffer tag,time>
+      @type file
+
+      path /fluentd/buffer/s3-buffer
+
+      timekey 3600
+      timekey_wait 10m
+      timekey_use_utc true
+
+      flush_at_shutdown true
+      retry_forever true
+      retry_max_interval 128s
+    </buffer>
+  </store>
+  {{ end }}
+
+  <store>
+    @type elasticsearch
+    host ${elasticsearch_host}
+    scheme https
+    logstash_format true
+    logstash_prefix "$${tag}"
+    port ${elasticsearch_port}
+    flush_interval 5s
+    include_tag_key true
+
+    # Mapping types are removed:
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html
+    # We use _doc for future support
+    type_name ${es6_support ? "_doc" : "log"}
+
+    request_timeout 15s
+    reload_on_failure true
+    # required for AWS ES
+    # https://github.com/gas-buddy/docker-fluentd/pull/1#issuecomment-302219959
+    max_retry_wait 30
+    disable_retry_limit
+    reconnect_on_error true
+
+    <buffer>
+      @type file
+
+      path /fluentd/buffer/es-buffer
+      flush_at_shutdown true
+      flush_mode interval
+      flush_interval 5s
+      retry_forever true
+      retry_max_interval 128s
+      timekey_use_utc false
+    </buffer>
+  </store>
+<match>

--- a/modules/fluentd_pre/variables.tf
+++ b/modules/fluentd_pre/variables.tf
@@ -1,0 +1,76 @@
+#############################
+# For Tagging Logs
+#############################
+
+variable "consul_key_prefix" {
+  description = <<EOF
+        Path prefix to the key in Consul to set for the `core` module to know that this module has
+        been applied. If you change this, you have to update the
+        `integration_consul_prefix` variable in the core module as well.
+EOF
+
+  default = "terraform/"
+}
+
+#############################
+# Elasticsearch related
+#############################
+variable "elasticsearch_host" {
+  description = "Elasticsearch endpoint used to submit index, search, and data upload requests"
+}
+
+variable "elasticsearch_port" {
+  description = "Elasticsearch service port"
+}
+
+variable "artifacts_base_path" {
+  description = "Base path to output file artifacts. Use `get_terragrunt_dir()` with an `extra_argument` to provide this value"
+  default     = "./"
+}
+
+
+#############################
+# S3 Logging related
+#############################
+variable "logs_s3_enabled" {
+  description = "Enable to log to S3"
+  default     = true
+}
+
+variable "logs_s3_bucket_name" {
+  description = "Name of S3 bucket to store logs for long term archival"
+  default     = ""
+}
+
+variable "logs_s3_abort_incomplete_days" {
+  description = "Specifies the number of days after initiating a multipart upload when the multipart upload must be completed."
+  default     = 7
+}
+
+variable "logs_s3_ia_transition_days" {
+  description = "Number of days before logs are transitioned to IA. Must be > 30 days"
+  default     = 90
+}
+
+variable "logs_s3_glacier_transition_days" {
+  description = "Number of days before logs are transitioned to IA. Must be > var.logs_s3_ia_transition_days + 30 days"
+  default     = 365
+}
+
+variable "logs_s3_policy" {
+  description = "Name of the IAM policy to provision for write access to the bucket"
+  default     = "LogsS3Write_New"
+}
+
+variable "logs_s3_storage_class" {
+  description = "Default storage class to store logs in S3. Choose from `STANDARD`, `REDUCED_REDUNDANCY` or `STANDARD_IA`"
+  default     = "STANDARD"
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+
+  default = {
+    Terraform = "true"
+  }
+}

--- a/modules/nexus/packer/ami/site.yml
+++ b/modules/nexus/packer/ami/site.yml
@@ -16,6 +16,7 @@
     consul_scheme: https
     consul_token: ""
     consul_integration_prefix: "terraform/"
+    for_fluentd_server: "no"
     timezone: "Asia/Singapore"
   tasks:
   - name: Upgrade all packages to the latest version

--- a/modules/prometheus/packer/ami/site.yml
+++ b/modules/prometheus/packer/ami/site.yml
@@ -23,6 +23,7 @@
     prometheus_client_service: "prometheus-client"
     prometheus_consul_job_name: "consul"
     prometheus_port: 9090
+    for_fluentd_server: "no"
   tasks:
   - name: Upgrade all packages to the latest version
     apt:

--- a/roles/td-agent/files/run-td-agent-fluentd-server.sh
+++ b/roles/td-agent/files/run-td-agent-fluentd-server.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_NAME="$(basename "$0")"
+
+readonly MAX_RETRIES=30
+readonly SLEEP_BETWEEN_RETRIES_SEC=10
+
+function print_usage {
+  echo
+  echo "Usage: run-td-agent [OPTIONS]"
+  echo
+  echo "This script is used to configure td-agent on an AWS server."
+  echo
+  echo "Options:"
+  echo
+  echo -e "  --rotate-age\t\tLog rotation age. Optional. Defaults to 5"
+  echo -e "  --rotate-size\t\tLog rotation size. Optional. Defaults to 104857600"
+  echo
+  echo "Example:"
+  echo
+  echo "  run-td-agent --conf-out /etc/td-agent/td-agent.conf"
+}
+
+function log {
+  local readonly level="$1"
+  local readonly message="$2"
+  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  >&2 echo -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
+}
+
+function log_info {
+  local readonly message="$1"
+  log "INFO" "${message}"
+}
+
+function log_warn {
+  local readonly message="$1"
+  log "WARN" "${message}"
+}
+
+function log_error {
+  local readonly message="$1"
+  log "ERROR" "${message}"
+}
+
+function assert_not_empty {
+  local readonly arg_name="$1"
+  local readonly arg_value="$2"
+
+  if [[ -z "${arg_value}" ]]; then
+    log_error "The value for '${arg_name}' cannot be empty"
+    print_usage
+    exit 1
+  fi
+}
+
+function assert_is_installed {
+  local readonly name="$1"
+
+  if [[ ! $(command -v ${name}) ]]; then
+    log_error "The binary '${name}' is required by this script but is not installed or in the system's PATH."
+    exit 1
+  fi
+}
+
+function enable_td_agent {
+  local readonly service_override_dir="${1}"
+  local readonly rotate_age="${2}"
+  local readonly rotate_size="${3}"
+
+  log_info "Enabling and starting service td-agent for Fluentd service ..."
+
+  mkdir -p "${service_override_dir}"
+
+  # To override an existing value ExecStart, the value must be set to empty first
+  local readonly override_conf=$(cat <<EOF
+[Service]
+ExecStart=
+ExecStart=/opt/td-agent/embedded/bin/fluentd --log /var/log/td-agent/td-agent.log --log-rotate-age ${rotate_age} --log-rotate-size ${rotate_size} --daemon /var/run/td-agent/td-agent.pid \$TD_AGENT_OPTIONS
+EOF
+)
+  echo "${override_conf}" > "${service_override_dir}/override.conf"
+
+  systemctl enable td-agent
+  systemctl start td-agent
+
+  log_info "Service td-agent enabled and started!"
+}
+
+function main {
+  local conf_out="/etc/td-agent/td-agent.conf"
+  local rotate_age="5"
+  local rotate_size="104857600"
+
+  local readonly service_override_dir="/etc/systemd/system/td-agent.service.d"
+
+  while [[ $# > 0 ]]; do
+    local key="$1"
+
+    case "$key" in
+      --rotate-age)
+        assert_not_empty "$key" "$2"
+        rotate_age="$2"
+        shift
+        ;;
+      --rotate-size)
+        assert_not_empty "$key" "$2"
+        rotate_size="$2"
+        shift
+        ;;
+      --help)
+        print_usage
+        exit
+        ;;
+      *)
+        log_error "Unrecognized argument: $key"
+        print_usage
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+  enable_td_agent "${service_override_dir}" "${rotate_age}" "${rotate_size}"
+
+}
+
+main "$@"

--- a/roles/td-agent/files/run-td-agent.sh
+++ b/roles/td-agent/files/run-td-agent.sh
@@ -24,6 +24,8 @@ function print_usage {
   echo -e "  --skip-template\t\tEnable consul-template apply on configuration file. Optional. Defaults to false."
   echo -e "  --conf-template\t\tFile path to configuration consul-template file. Optional. Defaults to /etc/td-agent/td-agent.conf.template"
   echo -e "  --conf-out\t\tFile path to configuration destination. Optional. Defaults to /etc/td-agent/td-agent.conf"
+  echo -e "  --rotate-age\t\tLog rotation age. Optional. Defaults to 5"
+  echo -e "  --rotate-size\t\tLog rotation size. Optional. Defaults to 104857600"
   echo
   echo "Example:"
   echo

--- a/roles/td-agent/tasks/main.yml
+++ b/roles/td-agent/tasks/main.yml
@@ -25,23 +25,41 @@
     groups: systemd-journal
     append: yes
   become: yes
+# Add configuration file
 - name: Include configuration variables
   include_vars:
     file: "{{ config_vars_file }}"
     name: config_vars
   when: config_vars_file != ""
+# Place different configuration file depending on if this is the aggregator
 - name: Change td-agent configuration
   template:
     src: "{{ config_file }}"
     dest: "{{ config_dest_file }}"
     mode: 0644
-  when: config_file != ""
+  when: config_file != "" and for_fluentd_server == "no"
   become: yes
+- name: Change td-agent configuration
+  copy:
+    src: "{{ fluentd_server_config_file }}"
+    dest: "{{ config_dest_file }}"
+    mode: 0644
+  when: fluentd_server_config_file != "" and for_fluentd_server == "yes"
+  become: yes
+# Use a different configuration script depending on if this is the aggregator
 - name: Install configuration script
   copy:
     src: "{{ role_path }}/files/run-td-agent.sh"
     dest: "/opt/run-td-agent"
     mode: 0755
+  when: for_fluentd_server == "no"
+  become: yes
+- name: Install configuration script (Fluentd service)
+  copy:
+    src: "{{ role_path }}/files/run-td-agent-fluentd-server.sh"
+    dest: "/opt/run-td-agent"
+    mode: 0755
+  when: for_fluentd_server == "yes"
   become: yes
 # See `use: service` issue: https://github.com/ansible/ansible-modules-core/issues/3764#issuecomment-284331673
 - name: Disable the td-agent service for next configuration set-up


### PR DESCRIPTION
The ultimate goal is to start an ASG for Fluentd without making use 
of Nomad, Consul or Vault services. This is so that these services 
can write to Fluentd log aggregator when they start up. 

In this PR, a `fluentd-pre` module is created to fill in the 
template for the `fluentd.conf` file to be configured for the Fluentd 
AMI. The reason to have a separate `fluentd-pre` module is because we 
need the output URL from an already running Elasticsearch, which is 
filled into the template for `fluentd-conf`, and we use this when 
provisioning the Fluentd AMI with Ansible.

The rest of the Fluentd setup is done after the AMI is provisioned.
Note that Elasticsearch currently does not use Route53 nor have URL
output yet - will be done in another PR. 