### PR TITLE
refactor(es): remove dependency on consul

### DIFF
--- a/modules/elasticsearch/INOUT.md
+++ b/modules/elasticsearch/INOUT.md
@@ -3,7 +3,6 @@
 | Name | Version |
 |------|---------|
 | aws | >= 2.7 |
-| consul | >= 2.5 |
 
 ## Inputs
 
@@ -30,7 +29,6 @@
 | es\_access\_cidr\_block | Elasticsearch access CIDR block to allow access | `list(string)` | n/a | yes |
 | es\_additional\_tags | Additional tags to apply on Elasticsearch | `map(string)` | `{}` | no |
 | es\_base\_domain | Base domain for Elasticsearch cluster | `string` | n/a | yes |
-| es\_consul\_service | Name to register in consul to identify Elasticsearch service | `string` | `"elasticsearch"` | no |
 | es\_dedicated\_master\_enabled | Enable dedicated master nodes for Elasticsearch | `bool` | n/a | yes |
 | es\_default\_access | Rest API / Web UI access | `map(any)` | <pre>{<br>  "port": 443,<br>  "protocol": "tcp",<br>  "type": "ingress"<br>}<br></pre> | no |
 | es\_domain\_name | Elasticsearch domain name | `string` | n/a | yes |
@@ -77,8 +75,6 @@
 | kms\_key\_inaccessible\_evaluation\_periods | Number of periods to evaluate for the alarm. | `string` | `"1"` | no |
 | kms\_key\_inaccessible\_period | Duration in seconds to evaluate for the alarm. | `string` | `"60"` | no |
 | kms\_key\_inaccessible\_threshold | Threshold for the number of kms key inaccessible error | `string` | `"1"` | no |
-| lb\_cname | DNS CNAME for the Load balancer | `string` | `""` | no |
-| lb\_zone\_id | Zone ID for the Load balancer DNS CNAME | `string` | `""` | no |
 | low\_storage\_space\_enable | Whether to enable alarm | `bool` | `false` | no |
 | low\_storage\_space\_evaluation\_periods | Number of periods to evaluate for the alarm. | `string` | `"1"` | no |
 | low\_storage\_space\_name | Name of the alarm | `string` | `"low_storage_space_alarm"` | no |
@@ -88,10 +84,6 @@
 | node\_unreachable\_evaluation\_periods | Number of periods to evaluate for the alarm. | `string` | `"1"` | no |
 | node\_unreachable\_period | Duration in seconds to evaluate for the alarm. | `string` | `"86400"` | no |
 | ok\_actions | A list of ARNs (i.e. SNS Topic ARN) to notify for ok action | `list(string)` | `[]` | no |
-| redirect\_domain | Domain name to redirect | `string` | `""` | no |
-| redirect\_listener\_arn | LB listener ARN to attach the rule to | `string` | `""` | no |
-| redirect\_route53\_zone\_id | Route53 Zone ID to create the Redirect Record in | `string` | `""` | no |
-| redirect\_rule\_priority | Rule priority for redirect | `number` | `100` | no |
 | security\_group\_additional\_tags | Additional tags to apply on the security group | `map(string)` | `{}` | no |
 | security\_group\_name | Name of security group, leaving this empty generates a group name | `string` | n/a | yes |
 | security\_group\_vpc\_id | VPC ID to apply on the security group | `string` | n/a | yes |
@@ -103,7 +95,6 @@
 | snapshot\_failed\_evaluation\_periods | Number of periods to evaluate for the alarm. | `string` | `"1"` | no |
 | snapshot\_failed\_period | Duration in seconds to evaluate for the alarm. | `string` | `"60"` | no |
 | snapshot\_failed\_threshold | Threshold for the number of snapshot failed | `string` | `"1"` | no |
-| use\_redirect | Indicates whether to use redirect users | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -1,17 +1,8 @@
 # AWS Elasticsearch module
 
-This modules creates an Elasticsearch cluster in a domain, with (optional) redirection
-service to allow easy access to Kibana web interface.
-
-## Registered `consul` service name
-
-The registered `consul` service name is `elasticsearch`, and the default port
-used is `443`.
-
-The actual VPC service and port are registered in `consul`. Any other services
-that require Elasticsearch service should always use the actual VPC service
-name, since the service is hosted under SSL and the SSL certificate to accept is
-registered under the VPC name (and not the `consul` service name).
+This modules creates an Elasticsearch cluster in a domain without Consul service discovery
+or redirection to Kibana. This module should be run before Core and Fluentd so that
+Fluentd can send logs to Elasticsearch.
 
 ## Default Access Policy
 
@@ -33,19 +24,6 @@ the Terraform module, you will have to manually configure Elasticsearch to log s
 See the
 [instructions](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-createupdatedomains.html#es-createdomain-configure-slow-logs-indices)
 for how to do so.
-
-## Redirection
-
-The module can optionally setup an ELB listener rule to redirect users to the Kibana interface
-using a much friendlier URL.
-
-We recommend that you use the internal ELB that was created by the `Core` module. For example, the
-list below will list the pairs of variables in this module that can use the output from the `Core`
-module:
-
-- `var.lb_cname`: `module.core.internal_lb_dns_name`
-- `var.lb_zone_id`: `module.core.internal_lb_zone_id`
-- `var.redirect_listener_arn`: `module.core.internal_lb_https_listener_arn`
 
 ## Service Linked Role
 
@@ -92,15 +70,6 @@ module "es" {
 
   enable_slow_index_log = true
   slow_index_log_name   = "my-cloud-es-slow-index"
-
-  # Optional section for redirecting users to the unfriendly Kibana URL
-
-  use_redirect             = true
-  redirect_route53_zone_id = "xxx"
-  redirect_domain          = "kibana.xxx.xxx"
-  lb_cname                 = "${module.core.internal_lb_dns_name}"
-  lb_zone_id               = "${module.core.internal_lb_zone_id}"
-  redirect_listener_arn    = "${module.core.internal_lb_https_listener_arn}"
 }
 ```
 

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -86,11 +86,6 @@ variable "es_default_access" {
   }
 }
 
-variable "es_consul_service" {
-  description = "Name to register in consul to identify Elasticsearch service"
-  default     = "elasticsearch"
-}
-
 variable "es_version" {
   # Available versions: https://aws.amazon.com/elasticsearch-service/faqs/
   # Currently cannot use 6.X due to fluentd elasticsearch plugin output multiple type issue
@@ -160,45 +155,6 @@ variable "slow_index_additional_tags" {
 variable "slow_index_log_retention" {
   description = "Number of days to retain logs for."
   default     = "120"
-}
-
-#
-# Redirect related
-#
-
-variable "use_redirect" {
-  description = "Indicates whether to use redirect users "
-  default     = false
-}
-
-variable "redirect_route53_zone_id" {
-  description = "Route53 Zone ID to create the Redirect Record in"
-  default     = ""
-}
-
-variable "redirect_domain" {
-  description = "Domain name to redirect"
-  default     = ""
-}
-
-variable "lb_cname" {
-  description = "DNS CNAME for the Load balancer"
-  default     = ""
-}
-
-variable "lb_zone_id" {
-  description = "Zone ID for the Load balancer DNS CNAME"
-  default     = ""
-}
-
-variable "redirect_listener_arn" {
-  description = "LB listener ARN to attach the rule to"
-  default     = ""
-}
-
-variable "redirect_rule_priority" {
-  description = "Rule priority for redirect"
-  default     = 100
 }
 
 #

--- a/modules/elasticsearch/versions.tf
+++ b/modules/elasticsearch/versions.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-    aws    = ">= 2.7"
-    consul = ">= 2.5"
+    aws = ">= 2.7"
   }
 }

--- a/modules/elasticsearch_post/INOUT.md
+++ b/modules/elasticsearch_post/INOUT.md
@@ -1,0 +1,28 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| consul | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:-----:|
+| es\_consul\_service | Name to register in consul to identify Elasticsearch service | `string` | `"elasticsearch"` | no |
+| es\_default\_access | Rest API / Web UI access | `map(any)` | <pre>{<br>  "port": 443,<br>  "protocol": "tcp",<br>  "type": "ingress"<br>}<br></pre> | no |
+| es\_endpoint | Domain-specific endpoint used to submit index, search, and data upload requests | `any` | n/a | yes |
+| es\_post\_access\_cidr\_block | Elasticsearch access CIDR block to allow access | `list(string)` | n/a | yes |
+| es\_security\_group\_id | ID of the Security Group attached to Elasticsearch | `any` | n/a | yes |
+| lb\_cname | DNS CNAME for the Load balancer | `string` | `""` | no |
+| lb\_zone\_id | Zone ID for the Load balancer DNS CNAME | `string` | `""` | no |
+| redirect\_domain | Domain name to redirect | `string` | `""` | no |
+| redirect\_listener\_arn | LB listener ARN to attach the rule to | `string` | `""` | no |
+| redirect\_route53\_zone\_id | Route53 Zone ID to create the Redirect Record in | `string` | `""` | no |
+| redirect\_rule\_priority | Rule priority for redirect | `number` | `100` | no |
+| use\_redirect | Indicates whether to use redirect users | `bool` | `false` | no |
+
+## Outputs
+
+No output.
+

--- a/modules/elasticsearch_post/README.md
+++ b/modules/elasticsearch_post/README.md
@@ -1,0 +1,32 @@
+# AWS Elasticsearch-post module
+
+This module provides the additional Consul registration and redirection to Kibana to
+an already running Elasticsearch module. This should be run only after Elasticsearch
+and Core are up.
+
+## Registered `consul` service name
+
+The registered `consul` service name is `elasticsearch`, and the default port
+used is `443`.
+
+The actual VPC service and port are registered in `consul`. Any other services
+that require Elasticsearch service should always use the actual VPC service
+name, since the service is hosted under SSL and the SSL certificate to accept is
+registered under the VPC name (and not the `consul` service name).
+
+## Redirection
+
+The module can optionally setup an ELB listener rule to redirect users to the Kibana interface
+using a much friendlier URL.
+
+We recommend that you use the internal ELB that was created by the `Core` module. For example, the
+list below will list the pairs of variables in this module that can use the output from the `Core`
+module:
+
+- `var.lb_cname`: `module.core.internal_lb_dns_name`
+- `var.lb_zone_id`: `module.core.internal_lb_zone_id`
+- `var.redirect_listener_arn`: `module.core.internal_lb_https_listener_arn`
+
+## Inputs and Outputs
+
+Refer to [INOUT.md](INOUT.md)

--- a/modules/elasticsearch_post/consul.tf
+++ b/modules/elasticsearch_post/consul.tf
@@ -1,6 +1,6 @@
 resource "consul_node" "es" {
   name    = var.es_consul_service
-  address = local.endpoint
+  address = var.es_endpoint
 }
 
 resource "consul_service" "es" {

--- a/modules/elasticsearch_post/main.tf
+++ b/modules/elasticsearch_post/main.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group_rule" "es_post_access_rule" {
+  type              = var.es_default_access["type"]
+  from_port         = var.es_default_access["port"]
+  to_port           = var.es_default_access["port"]
+  protocol          = var.es_default_access["protocol"]
+  cidr_blocks       = var.es_post_access_cidr_block
+  security_group_id = var.es_security_group_id
+}

--- a/modules/elasticsearch_post/redirect.tf
+++ b/modules/elasticsearch_post/redirect.tf
@@ -23,7 +23,7 @@ resource "aws_lb_listener_rule" "redirect" {
     type = "redirect"
 
     redirect {
-      host        = local.endpoint
+      host        = var.es_endpoint
       path        = "/_plugin/kibana/#{path}"
       port        = 443
       protocol    = "HTTPS"

--- a/modules/elasticsearch_post/variables.tf
+++ b/modules/elasticsearch_post/variables.tf
@@ -1,0 +1,75 @@
+#
+# Consul related
+#
+
+variable "es_consul_service" {
+  description = "Name to register in consul to identify Elasticsearch service"
+  default     = "elasticsearch"
+}
+
+#
+# ES access
+#
+
+variable "es_endpoint" {
+  description = "Domain-specific endpoint used to submit index, search, and data upload requests"
+}
+
+variable "es_default_access" {
+  description = "Rest API / Web UI access"
+  type        = map(any)
+
+  default = {
+    type     = "ingress"
+    protocol = "tcp"
+    port     = 443
+  }
+}
+
+variable "es_post_access_cidr_block" {
+  description = "Elasticsearch access CIDR block to allow access"
+  type        = list(string)
+}
+
+variable "es_security_group_id" {
+  description = "ID of the Security Group attached to Elasticsearch"
+}
+
+#
+# Redirect related
+#
+
+variable "use_redirect" {
+  description = "Indicates whether to use redirect users "
+  default     = false
+}
+
+variable "redirect_route53_zone_id" {
+  description = "Route53 Zone ID to create the Redirect Record in"
+  default     = ""
+}
+
+variable "redirect_domain" {
+  description = "Domain name to redirect"
+  default     = ""
+}
+
+variable "lb_cname" {
+  description = "DNS CNAME for the Load balancer"
+  default     = ""
+}
+
+variable "lb_zone_id" {
+  description = "Zone ID for the Load balancer DNS CNAME"
+  default     = ""
+}
+
+variable "redirect_listener_arn" {
+  description = "LB listener ARN to attach the rule to"
+  default     = ""
+}
+
+variable "redirect_rule_priority" {
+  description = "Rule priority for redirect"
+  default     = 100
+}


### PR DESCRIPTION
Refactor Elasticsearch into Elasticsearch and Elasticsearch-post, to 
work with `l-cloud` #400.