### PR TITLE
fix: add vars to enable and config master nodes

### DIFF
--- a/modules/elasticsearch/INOUT.md
+++ b/modules/elasticsearch/INOUT.md
@@ -29,20 +29,20 @@
 | enable\_slow\_index\_log | Enable slow log indexing | `bool` | `false` | no |
 | es\_access\_cidr\_block | Elasticsearch access CIDR block to allow access | `list(string)` | n/a | yes |
 | es\_additional\_tags | Additional tags to apply on Elasticsearch | `map(string)` | `{}` | no |
-| es\_base\_domain | Base domain for Elasticsearch cluster | `any` | n/a | yes |
+| es\_base\_domain | Base domain for Elasticsearch cluster | `string` | n/a | yes |
 | es\_consul\_service | Name to register in consul to identify Elasticsearch service | `string` | `"elasticsearch"` | no |
-| es\_dedicated\_master\_enabled | Enable dedicated master nodes for Elasticsearch | `any` | n/a | yes |
+| es\_dedicated\_master\_enabled | Enable dedicated master nodes for Elasticsearch | `bool` | n/a | yes |
 | es\_default\_access | Rest API / Web UI access | `map(any)` | <pre>{<br>  "port": 443,<br>  "protocol": "tcp",<br>  "type": "ingress"<br>}<br></pre> | no |
-| es\_domain\_name | Elasticsearch domain name | `any` | n/a | yes |
-| es\_ebs\_volume\_size | Volume capacity for attached EBS in GB for each node | `any` | n/a | yes |
-| es\_ebs\_volume\_type | Storage type of EBS volumes, if used (default gp2) | `any` | n/a | yes |
+| es\_domain\_name | Elasticsearch domain name | `string` | n/a | yes |
+| es\_ebs\_volume\_size | Volume capacity for attached EBS in GB for each node | `number` | n/a | yes |
+| es\_ebs\_volume\_type | Storage type of EBS volumes, if used (default gp2) | `string` | n/a | yes |
 | es\_encrypt\_at\_rest | Encrypts the data stored by Elasticsearch at rest | `bool` | `false` | no |
 | es\_http\_iam\_roles | List of IAM role ARNs from which to permit Elasticsearch HTTP traffic (default ['\*']).<br>Note that a client must match both the IP address and the IAM role patterns in order to be permitted access. | `list(string)` | <pre>[<br>  "*"<br>]<br></pre> | no |
-| es\_instance\_count | Number of nodes to be deployed in Elasticsearch | `any` | n/a | yes |
-| es\_instance\_type | Elasticsearch instance type for non-master node | `any` | n/a | yes |
+| es\_instance\_count | Number of nodes to be deployed in Elasticsearch | `number` | n/a | yes |
+| es\_instance\_type | Elasticsearch instance type for non-master node | `string` | n/a | yes |
 | es\_kms\_key\_id | kms Key ID for encryption at rest. Defaults to AWS service key. | `string` | `"aws/es"` | no |
-| es\_master\_count | Number of dedicated master nodes in Elasticsearch | `any` | n/a | yes |
-| es\_master\_type | Elasticsearch instance type for dedicated master node | `any` | n/a | yes |
+| es\_master\_count | Number of dedicated master nodes in Elasticsearch | `number` | n/a | yes |
+| es\_master\_type | Elasticsearch instance type for dedicated master node | `string` | n/a | yes |
 | es\_snapshot\_start\_hour | Hour at which automated snapshots are taken, in UTC (default 0) | `number` | `19` | no |
 | es\_version | Elasticsearch version to deploy | `string` | `"5.5"` | no |
 | es\_vpc\_subnet\_ids | Subnet IDs for Elasticsearch cluster | `list(string)` | n/a | yes |
@@ -93,8 +93,8 @@
 | redirect\_route53\_zone\_id | Route53 Zone ID to create the Redirect Record in | `string` | `""` | no |
 | redirect\_rule\_priority | Rule priority for redirect | `number` | `100` | no |
 | security\_group\_additional\_tags | Additional tags to apply on the security group | `map(string)` | `{}` | no |
-| security\_group\_name | Name of security group, leaving this empty generates a group name | `any` | n/a | yes |
-| security\_group\_vpc\_id | VPC ID to apply on the security group | `any` | n/a | yes |
+| security\_group\_name | Name of security group, leaving this empty generates a group name | `string` | n/a | yes |
+| security\_group\_vpc\_id | VPC ID to apply on the security group | `string` | n/a | yes |
 | slow\_index\_additional\_tags | Additional tags to apply on Cloudwatch log group | `map(string)` | `{}` | no |
 | slow\_index\_log\_name | Name of the Cloudwatch log group for slow index | `string` | `"es-slow-index"` | no |
 | slow\_index\_log\_retention | Number of days to retain logs for. | `string` | `"120"` | no |

--- a/modules/elasticsearch/INOUT.md
+++ b/modules/elasticsearch/INOUT.md
@@ -31,6 +31,7 @@
 | es\_additional\_tags | Additional tags to apply on Elasticsearch | `map(string)` | `{}` | no |
 | es\_base\_domain | Base domain for Elasticsearch cluster | `any` | n/a | yes |
 | es\_consul\_service | Name to register in consul to identify Elasticsearch service | `string` | `"elasticsearch"` | no |
+| es\_dedicated\_master\_enabled | Enable dedicated master nodes for Elasticsearch | `any` | n/a | yes |
 | es\_default\_access | Rest API / Web UI access | `map(any)` | <pre>{<br>  "port": 443,<br>  "protocol": "tcp",<br>  "type": "ingress"<br>}<br></pre> | no |
 | es\_domain\_name | Elasticsearch domain name | `any` | n/a | yes |
 | es\_ebs\_volume\_size | Volume capacity for attached EBS in GB for each node | `any` | n/a | yes |
@@ -40,6 +41,7 @@
 | es\_instance\_count | Number of nodes to be deployed in Elasticsearch | `any` | n/a | yes |
 | es\_instance\_type | Elasticsearch instance type for non-master node | `any` | n/a | yes |
 | es\_kms\_key\_id | kms Key ID for encryption at rest. Defaults to AWS service key. | `string` | `"aws/es"` | no |
+| es\_master\_count | Number of dedicated master nodes in Elasticsearch | `any` | n/a | yes |
 | es\_master\_type | Elasticsearch instance type for dedicated master node | `any` | n/a | yes |
 | es\_snapshot\_start\_hour | Hour at which automated snapshots are taken, in UTC (default 0) | `number` | `19` | no |
 | es\_version | Elasticsearch version to deploy | `string` | `"5.5"` | no |

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -76,7 +76,7 @@ module "es" {
   es_base_domain       = "${data.terraform_remote_state.core.base_domain}"
   es_access_cidr_block = ["1.3.1.4"]
 
-  es_master_type     = "r4.xlarge.elasticsearch"
+  es_master_type     = "r5.xlarge.elasticsearch"
   es_instance_type   = "r4.xlarge.elasticsearch"
   es_instance_count  = "3"
   es_ebs_volume_size = "100"  # in GB

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -47,9 +47,9 @@ resource "aws_elasticsearch_domain" "es" {
   cluster_config {
     instance_type            = var.es_instance_type
     instance_count           = var.es_instance_count
-    dedicated_master_enabled = var.es_instance_count >= 10 ? true : false
-    dedicated_master_count   = var.es_instance_count >= 10 ? 3 : 0
-    dedicated_master_type    = var.es_instance_count >= 10 ? (var.es_master_type != "false" ? var.es_master_type : var.es_instance_type) : ""
+    dedicated_master_enabled = var.es_dedicated_master_enabled
+    dedicated_master_count   = var.es_master_count
+    dedicated_master_type    = var.es_master_type
     zone_awareness_enabled   = var.es_zone_awareness
   }
 

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -4,18 +4,22 @@
 
 variable "security_group_name" {
   description = "Name of security group, leaving this empty generates a group name"
+  type        = string
 }
 
 variable "security_group_vpc_id" {
   description = "VPC ID to apply on the security group"
+  type        = string
 }
 
 variable "es_domain_name" {
   description = "Elasticsearch domain name"
+  type        = string
 }
 
 variable "es_base_domain" {
   description = "Base domain for Elasticsearch cluster"
+  type        = string
 }
 
 variable "es_access_cidr_block" {
@@ -30,32 +34,39 @@ variable "es_vpc_subnet_ids" {
 
 variable "es_dedicated_master_enabled" {
   description = "Enable dedicated master nodes for Elasticsearch"
+  type        = bool
 }
 
 variable "es_master_type" {
   # Available types: https://aws.amazon.com/elasticsearch-service/pricing/
   description = "Elasticsearch instance type for dedicated master node"
+  type        = string
 }
 
 variable "es_master_count" {
   description = "Number of dedicated master nodes in Elasticsearch"
+  type        = number
 }
 
 variable "es_instance_type" {
   description = "Elasticsearch instance type for non-master node"
+  type        = string
 }
 
 variable "es_instance_count" {
   # Available types: https://aws.amazon.com/elasticsearch-service/pricing/
   description = "Number of nodes to be deployed in Elasticsearch"
+  type        = number
 }
 
 variable "es_ebs_volume_size" {
   description = "Volume capacity for attached EBS in GB for each node"
+  type        = number
 }
 
 variable "es_ebs_volume_type" {
   description = "Storage type of EBS volumes, if used (default gp2)"
+  type        = string
 }
 
 variable "security_group_additional_tags" {

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -28,9 +28,17 @@ variable "es_vpc_subnet_ids" {
   type        = list(string)
 }
 
+variable "es_dedicated_master_enabled" {
+  description = "Enable dedicated master nodes for Elasticsearch"
+}
+
 variable "es_master_type" {
   # Available types: https://aws.amazon.com/elasticsearch-service/pricing/
   description = "Elasticsearch instance type for dedicated master node"
+}
+
+variable "es_master_count" {
+  description = "Number of dedicated master nodes in Elasticsearch"
 }
 
 variable "es_instance_type" {


### PR DESCRIPTION
Add non-optional three master nodes to ES cluster. ES domain name and
security group name were changed due to provisioning of new cluster.
Changing the domain name back requires another migration while 
destroying the SG caused errors. 