### PR TITLE
fix(prometheus): remove deprecated var for new packer version

### DIFF
--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -7,7 +7,9 @@ repository.
 
 ### Instance AMI
 
-You will have to build an AMI with the [Packer template](packer/packer.json) provided.
+You will have to build an AMI with the [Packer template](packer/packer.json) provided. 
+See https://github.com/cloudalchemy/ansible-prometheus/blob/3b866fd50d4b13c7ee4d7f45f7308354acbe3036/README.md for build instructions. 
+If you are using Mac as the deployer host, you may encounter the following issue: https://github.com/rbenv/ruby-build/issues/1385
 
 ```bash
 packer build \

--- a/modules/prometheus/packer/ami/packer.json
+++ b/modules/prometheus/packer/ami/packer.json
@@ -109,7 +109,7 @@
                 "-e",
                 "timezone={{user `timezone`}}",
                 "-e",
-                "ansible_python_interpreter=/usr/bin/python3"
+                "ansible_python_interpreter=\"$(command -v python3)\""
             ]
         }
     ]

--- a/modules/prometheus/packer/ami/packer.json
+++ b/modules/prometheus/packer/ami/packer.json
@@ -5,7 +5,7 @@
         "ami_base_name": "prometheus",
         "aws_region": "ap-southeast-1",
         "subnet_id": "",
-        "temporary_security_group_source_cidr": "0.0.0.0/0",
+        "temporary_security_group_source_cidrs": "0.0.0.0/0",
         "associate_public_ip_address": "true",
         "ssh_interface": "",
         "consul_module_repo": "https://github.com/hashicorp/terraform-aws-consul.git",
@@ -39,7 +39,7 @@
             "subnet_id": "{{user `subnet_id`}}",
             "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
             "ssh_interface": "{{user `ssh_interface`}}",
-            "temporary_security_group_source_cidr": "{{user `temporary_security_group_source_cidr`}}",
+            "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",
             "source_ami_filter": {
                 "filters": {
                     "virtualization-type": "hvm",

--- a/modules/prometheus/packer/data/packer.json
+++ b/modules/prometheus/packer/data/packer.json
@@ -5,7 +5,7 @@
         "volume_name": "prometheus-server-data",
         "aws_region": "ap-southeast-1",
         "subnet_id": "",
-        "temporary_security_group_source_cidr": "0.0.0.0/0",
+        "temporary_security_group_source_cidrs": "0.0.0.0/0",
         "associate_public_ip_address": "true",
         "ssh_interface": "",
         "data_volume_size": "400"
@@ -19,7 +19,7 @@
             "subnet_id": "{{user `subnet_id`}}",
             "associate_public_ip_address": "{{user `associate_public_ip_address`}}",
             "ssh_interface": "{{user `ssh_interface`}}",
-            "temporary_security_group_source_cidr": "{{user `temporary_security_group_source_cidr`}}",
+            "temporary_security_group_source_cidrs": "{{user `temporary_security_group_source_cidrs`}}",
             "source_ami_filter": {
                 "filters": {
                     "virtualization-type": "hvm",


### PR DESCRIPTION
https://github.com/hashicorp/packer/blob/master/CHANGELOG.md
```
builder/amazon: Change temporary_security_group_source_cidr to
temporary_security_group_source_cidrs and allow it to accept a list of strings.
[GH-7450]
```

Thanks to @qbiqing for helping to find the issue in building the AMI for Prometheus.