### PR TITLE
fix(fluentd): disable storing logs locally

### DIFF
--- a/modules/fluentd_pre/INOUT.md
+++ b/modules/fluentd_pre/INOUT.md
@@ -15,6 +15,7 @@
 | elasticsearch\_port | Elasticsearch service port | `any` | n/a | yes |
 | fluentd\_match | Tags that fluentd should output to S3 and Elasticsearch | `any` | n/a | yes |
 | fluentd\_port | Port on the Docker image in which the HTTP interface is exposed | `number` | `4224` | no |
+| logs\_local\_store\_enabled | Enable to store copy of logs on the local machine | `bool` | `false` | no |
 | logs\_s3\_abort\_incomplete\_days | Specifies the number of days after initiating a multipart upload when the multipart upload must be completed. | `number` | `7` | no |
 | logs\_s3\_bucket\_name | Name of S3 bucket to store logs for long term archival | `any` | n/a | yes |
 | logs\_s3\_enabled | Enable to log to S3 | `bool` | `true` | no |

--- a/modules/fluentd_pre/main.tf
+++ b/modules/fluentd_pre/main.tf
@@ -14,11 +14,12 @@ data "template_file" "fluentd_conf" {
     fluentd_port  = var.fluentd_port
     fluentd_match = var.fluentd_match
 
-    s3_bucket       = aws_s3_bucket.logs[0].id
-    s3_region       = "ap-southeast-1"
-    s3_prefix       = "logs/"
-    storage_class   = var.logs_s3_storage_class
-    logs_s3_enabled = var.logs_s3_enabled
+    s3_bucket                = aws_s3_bucket.logs[0].id
+    s3_region                = "ap-southeast-1"
+    s3_prefix                = "logs/"
+    storage_class            = var.logs_s3_storage_class
+    logs_s3_enabled          = var.logs_s3_enabled
+    logs_local_store_enabled = var.logs_local_store_enabled
   }
 }
 

--- a/modules/fluentd_pre/templates/fluent.conf
+++ b/modules/fluentd_pre/templates/fluent.conf
@@ -10,6 +10,7 @@
 <match ${fluentd_match}>
   @type copy
 
+  %{ if logs_local_store_enabled }
   <store ignore_error>
     @type file
 
@@ -25,6 +26,7 @@
       timekey_use_utc false
     </buffer>
   </store>
+  %{ endif }
 
   %{ if logs_s3_enabled }
   <store>

--- a/modules/fluentd_pre/variables.tf
+++ b/modules/fluentd_pre/variables.tf
@@ -27,6 +27,11 @@ variable "fluentd_port" {
   default     = 4224
 }
 
+variable "logs_local_store_enabled" {
+  description = "Enable to store copy of logs on the local machine"
+  default     = false
+}
+
 #############################
 # S3 Logging related
 #############################


### PR DESCRIPTION
Storing logs on the instance was enabled which causes device to be out 
of space, and kills `td-agent`. No need to store locally since logs are
sent to S3 and Elasticsearch.