### PR TITLE
chore(fluentd): optimize memory and CPU usage

### DIFF
--- a/modules/fluentd_new/README.md
+++ b/modules/fluentd_new/README.md
@@ -53,7 +53,7 @@ job "job" {
           type = "fluentd"
 
           config = {
-            fluentd-address = "fluentd.locus.rocks:4224"
+            fluentd-address = "<fluentd-hostname>:4224"
             tag             = "docker.job"
           }
         }

--- a/modules/fluentd_pre/templates/fluent.conf
+++ b/modules/fluentd_pre/templates/fluent.conf
@@ -1,3 +1,7 @@
+<system>
+  workers 2
+</system>
+
 <source>
   @type forward
   port ${fluentd_port}
@@ -31,13 +35,13 @@
   %{ if logs_s3_enabled }
   <store>
     @type s3
+    store_as gzip_command
 
     s3_bucket "${s3_bucket}"
     s3_region "${s3_region}"
 
     path "${s3_prefix}%Y/%m/%d/%H/$${tag}/"
-    s3_object_key_format "%%{path}%%{time_slice}_%%{hex_random}_%%{index}.%%{file_extension}"
-    buffer_path "buffer/"
+    s3_object_key_format "%%{path}%%{time_slice}_%%{hex_random}_%%{index}_$${chunk_id}.%%{file_extension}"
     storage_class "${storage_class}"
 
     auto_create_bucket false
@@ -53,6 +57,7 @@
       timekey_use_utc true
 
       flush_at_shutdown true
+      flush_thread_count 8
       retry_forever true
       retry_max_interval 128s
     </buffer>
@@ -76,10 +81,6 @@
 
     request_timeout 15s
     reload_on_failure true
-    # required for AWS ES
-    # https://github.com/gas-buddy/docker-fluentd/pull/1#issuecomment-302219959
-    max_retry_wait 30
-    disable_retry_limit
     reconnect_on_error true
 
     <buffer>
@@ -89,6 +90,7 @@
       flush_at_shutdown true
       flush_mode interval
       flush_interval 5s
+      flush_thread_count 8
       retry_forever true
       retry_max_interval 128s
       timekey_use_utc false


### PR DESCRIPTION
Memory and CPU bottlenecks were observed with large log traffic. Flush
thread count is increased to 8 and gzip compression is done as a separate
process as recommended in [[1]], to optimize memory usage. Number of workers
is also increased to 2 to make use of 2 CPUs, to address CPU bottleneck
identified by logs similar to [[2]] and as recommended by [[3]]. Unused vars
are removed.

[1]: https://docs.fluentd.org/deployment/performance-tuning-single-process
[2]: https://groups.google.com/g/fluentd/c/3xrieNheguE
[3]: https://docs.fluentd.org/deployment/multi-process-workers