### PR TITLE
chore: remove placement_tenancy

### DIFF
--- a/modules/nomad-cluster/README.md
+++ b/modules/nomad-cluster/README.md
@@ -1,6 +1,14 @@
 # Nomad Cluster
 
-This is a copy-pasted version of [HashiCorp's Nomad Cluster](github.com/hashicorp/terraform-aws-nomad//modules/nomad-cluster?ref=v0.7.0) but with the addition of a spot price variable which was excluded in the original module.
+This is a copy-pasted version of [HashiCorp's Nomad Cluster](github.com/hashicorp/terraform-aws-nomad//modules/nomad-cluster?ref=v0.7.0) 
+but with the addition of a spot price variable which was excluded in the original module.
+
+Note: since `placement_tenancy` is a variable that's specific to reserved instances, it's removed in order to use `spot_price` to mix
+both spot and reserved/on demand instances in the launch configuration.
+
+https://docs.amazonaws.cn/en_us/autoscaling/ec2/userguide/auto-scaling-dedicated-instances.html
+
+> When you create a launch configuration, the default value for the instance placement tenancy is null and the instance tenancy is controlled by the tenancy attribute of the VPC. You can specify the instance placement tenancy for your launch configuration as default or dedicated using the create-launch-configuration CLI command with the --placement-tenancy option. 
 
 ## Inputs and Outputs
 

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -83,7 +83,6 @@ resource "aws_launch_configuration" "launch_configuration" {
     [aws_security_group.lc_security_group.id],
     var.security_groups,
   )
-  placement_tenancy           = var.tenancy
   associate_public_ip_address = var.associate_public_ip_address
 
   ebs_optimized = var.root_volume_ebs_optimized


### PR DESCRIPTION
`placement_tenancy` is not supported as a variable if we want to mix spot instances in our ASG for nomad clients. Further details are documented in the `README`.