### PR TITLE
chore(vault): update helper script

### DIFF
--- a/modules/core/INOUT.md
+++ b/modules/core/INOUT.md
@@ -36,6 +36,7 @@
 | elb\_access\_log\_prefix | Prefix in the S3 bucket to log internal LB access | `string` | `""` | no |
 | elb\_idle\_timeout | The time in seconds that the connection is allowed to be idle. Consul supports blocking requests that can last up to 600 seconds. Increase this to support that. | `number` | `660` | no |
 | elb\_ssl\_policy | ELB SSL policy for HTTPs listeners. See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html | `string` | `"ELBSecurityPolicy-TLS-1-2-2017-01"` | no |
+| iam\_permissions\_boundary | If set, restricts the created IAM role to the given permissions boundary | `string` | n/a | yes |
 | integration\_consul\_prefix | The Consul prefix used by the various integration scripts during initial instance boot. | `string` | `"terraform/"` | no |
 | internal\_lb\_certificate\_arn | ARN of the certificate to use for the internal LB | `any` | n/a | yes |
 | internal\_lb\_incoming\_cidr | A list of CIDR-formatted IP address ranges from which the internal Load balancer is allowed to listen to | `list(string)` | n/a | yes |

--- a/modules/core/consul.tf
+++ b/modules/core/consul.tf
@@ -8,7 +8,8 @@ locals {
 }
 
 module "consul_servers" {
-  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.8.3"
+  source  = "hashicorp/consul/aws//modules/consul-cluster"
+  version = "0.8.4"
 
   cluster_name  = var.consul_cluster_name
   cluster_size  = var.consul_cluster_size
@@ -35,6 +36,8 @@ module "consul_servers" {
 
   health_check_type    = "ELB"
   termination_policies = var.consul_termination_policies
+
+  iam_permissions_boundary = var.iam_permissions_boundary
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/core/nomad_clients.tf
+++ b/modules/core/nomad_clients.tf
@@ -38,4 +38,6 @@ module "nomad_clients" {
   integration_service_type  = "nomad_client"
 
   termination_policies = var.nomad_client_termination_policies
+
+  iam_permissions_boundary = var.iam_permissions_boundary
 }

--- a/modules/core/nomad_servers.tf
+++ b/modules/core/nomad_servers.tf
@@ -8,7 +8,8 @@ locals {
 }
 
 module "nomad_servers" {
-  source = "github.com/hashicorp/terraform-aws-nomad//modules/nomad-cluster?ref=v0.7.0"
+  source  = "hashicorp/nomad/aws//modules/nomad-cluster"
+  version = "0.7.1"
 
   asg_name          = "${var.nomad_cluster_name}-server"
   cluster_name      = "${var.nomad_cluster_name}-server"
@@ -37,6 +38,8 @@ module "nomad_servers" {
 
   health_check_type    = "ELB"
   termination_policies = var.nomad_server_termination_policies
+
+  iam_permissions_boundary = var.iam_permissions_boundary
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -478,6 +478,12 @@ variable "elb_idle_timeout" {
   default     = 660
 }
 
+variable "iam_permissions_boundary" {
+  description = "If set, restricts the created IAM role to the given permissions boundary"
+  type        = string
+  default     = null
+}
+
 # --------------------------------------------------------------------------------------------------
 # Post Bootstrap Integration Parameters
 # These parameters are used in conjunction with the other modules in this repository.

--- a/modules/core/vault-helper.sh
+++ b/modules/core/vault-helper.sh
@@ -52,7 +52,7 @@ function get_required_terraform_data_source_output {
   local readonly output_name="$2"
   local output_value
 
-  output_value=$(terragrunt show -json | jq -r "
+  output_value=$("${TERRAFORM}" show -json | jq -r "
     .values.root_module.resources |
     .[] |
     select(.address==\"data.terraform_remote_state.$data_source_name\") |
@@ -70,7 +70,7 @@ function get_optional_terraform_output {
   local readonly output_name="$1"
   local output_value
 
-  output_value=$(terragrunt show -json | jq -r "
+  output_value=$("${TERRAFORM}" show -json | jq -r "
     .values.outputs.$output_name.value")
 
   if [[ "$output_value" == "null" ]]; then

--- a/modules/core/vault-helper.sh
+++ b/modules/core/vault-helper.sh
@@ -47,9 +47,37 @@ function assert_is_installed {
   fi
 }
 
+function get_required_terraform_data_source_output {
+  local readonly data_source_name="$1"
+  local readonly output_name="$2"
+  local output_value
+
+  output_value=$(terragrunt show -json | jq -r "
+    .values.root_module.resources |
+    .[] |
+    select(.address==\"data.terraform_remote_state.$data_source_name\") |
+    .values.outputs.$output_name")
+
+  if [[ "$output_value" == "null" ]]; then
+    log_error "Unable to find Terraform data source $data_source_name with output $output_name"
+    exit 1
+  fi
+
+  echo "$output_value"
+}
+
 function get_optional_terraform_output {
   local readonly output_name="$1"
-  "${TERRAFORM}" output -no-color "$output_name"
+  local output_value
+
+  output_value=$(terragrunt show -json | jq -r "
+    .values.outputs.$output_name.value")
+
+  if [[ "$output_value" == "null" ]]; then
+    output_value=""
+  fi
+
+  echo "$output_value"
 }
 
 function get_required_terraform_output {
@@ -170,7 +198,7 @@ function get_vault_server_ips {
   local cluster_tag_value
   local instances
 
-  aws_region=$(get_required_terraform_output "vpc_region")
+  aws_region=$(get_required_terraform_data_source_output "vpc" "vpc_region")
   cluster_tag_key=$(get_required_terraform_output "vault_servers_cluster_tag_key")
   cluster_tag_value=$(get_required_terraform_output "vault_servers_cluster_tag_value")
 

--- a/modules/core/vault.tf
+++ b/modules/core/vault.tf
@@ -20,7 +20,8 @@ EOF
 }
 
 module "vault" {
-  source = "github.com/hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.13.4"
+  source  = "hashicorp/vault/aws//modules/vault-cluster"
+  version = "0.14.1"
 
   cluster_name  = var.vault_cluster_name
   cluster_size  = var.vault_cluster_size
@@ -50,6 +51,8 @@ module "vault" {
   auto_unseal_kms_key_arn = var.vault_auto_unseal_kms_key_arn
 
   termination_policies = var.vault_termination_policies
+
+  iam_permissions_boundary = var.iam_permissions_boundary
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/nomad-clients/INOUT.md
+++ b/modules/nomad-clients/INOUT.md
@@ -22,6 +22,7 @@
 | consul\_cluster\_name | Name of the Consul cluster to deploy | `string` | `"consul-nomad-prototype"` | no |
 | docker\_privileged | Flag to enable privileged mode for Docker driver on Nomad client | `bool` | `false` | no |
 | docker\_volumes\_mounting | Flag to enable volume mounting for Docker driver on Nomad client | `bool` | `false` | no |
+| iam\_permissions\_boundary | If set, restricts the created IAM role to the given permissions boundary | `string` | n/a | yes |
 | instance\_type | Type of instances to deploy Nomad servers to | `string` | `"t2.medium"` | no |
 | integration\_consul\_prefix | The Consul prefix used by the various integration scripts during initial instance boot. | `string` | `"terraform/"` | no |
 | integration\_service\_type | The 'server type' for this Nomad cluster. This is used in several integration.<br>If empty, this defaults to the `cluster_name` variable | `string` | `""` | no |

--- a/modules/nomad-clients/main.tf
+++ b/modules/nomad-clients/main.tf
@@ -41,6 +41,8 @@ module "nomad_clients" {
   associate_public_ip_address = var.associate_public_ip_address
 
   termination_policies = var.termination_policies
+
+  iam_permissions_boundary = var.iam_permissions_boundary
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -126,6 +126,12 @@ variable "termination_policies" {
   default     = "Default"
 }
 
+variable "iam_permissions_boundary" {
+  description = "If set, restricts the created IAM role to the given permissions boundary"
+  type        = string
+  default     = null
+}
+
 # --------------------------------------------------------------------------------------------------
 # Post Bootstrap Integration Parameters
 # These parameters are used in conjunction with the other modules in this repository.

--- a/modules/nomad-cluster/INOUT.md
+++ b/modules/nomad-cluster/INOUT.md
@@ -22,6 +22,7 @@
 | health\_check\_grace\_period | Time, in seconds, after instance comes into service before checking health. | `number` | `300` | no |
 | health\_check\_type | Controls how health checking is done. Must be one of EC2 or ELB. | `string` | `"EC2"` | no |
 | http\_port | The port to use for HTTP | `number` | `4646` | no |
+| iam\_permissions\_boundary | If set, restricts the created IAM role to the given permissions boundary | `string` | n/a | yes |
 | instance\_profile\_path | Path in which to create the IAM instance profile. | `string` | `"/"` | no |
 | instance\_type | The type of EC2 Instances to run for each node in the cluster (e.g. t2.micro). | `string` | n/a | yes |
 | max\_size | The maximum number of nodes to have in the cluster. If you're using this to run Nomad servers, we strongly recommend setting this to 3 or 5. | `number` | n/a | yes |

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -193,6 +193,8 @@ resource "aws_iam_role" "instance_role" {
   name_prefix        = var.cluster_name
   assume_role_policy = data.aws_iam_policy_document.instance_role.json
 
+  permissions_boundary = var.iam_permissions_boundary
+
   # aws_iam_instance_profile.instance_profile in this module sets create_before_destroy to true, which means
   # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors
   # when you try to do a terraform destroy.

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -233,3 +233,8 @@ variable "protect_from_scale_in" {
   default     = false
 }
 
+variable "iam_permissions_boundary" {
+  description = "If set, restricts the created IAM role to the given permissions boundary"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
For now the script still assumes certain output from derivator's `core`
module.

The `vpc_region` is now assumed to be returned by `vpc` instead.