### PR TITLE
feat(core): allow Nomad server and client separate names

### DIFF
--- a/modules/core/INOUT.md
+++ b/modules/core/INOUT.md
@@ -43,6 +43,7 @@
 | internal\_lb\_name | Name of the internal load balancer | `string` | `"internal"` | no |
 | internal\_lb\_subnets | List of subnets to deploy the internal LB to | `list(string)` | n/a | yes |
 | nomad\_api\_domain | Domain to access Nomad REST API | `any` | n/a | yes |
+| nomad\_client\_cluster\_name | Overrides `nomad_cluster_name` if specified. The name of the Nomad client cluster. | `string` | n/a | yes |
 | nomad\_client\_instance\_type | Type of instances to deploy Nomad servers to | `string` | `"t2.medium"` | no |
 | nomad\_client\_subnets | List of subnets to launch Nomad clients in | `list(string)` | n/a | yes |
 | nomad\_client\_termination\_policies | A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default. | `string` | `"Default"` | no |
@@ -57,7 +58,8 @@
 | nomad\_clients\_root\_volume\_type | The type of volume. Must be one of: standard, gp2, or io1. | `string` | `"gp2"` | no |
 | nomad\_clients\_services\_inbound\_cidr | A list of CIDR-formatted IP address ranges (in addition to the VPC range) from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from. | `list(string)` | `[]` | no |
 | nomad\_clients\_user\_data | The user data for the Nomad clients EC2 instances. If set to empty, the default template will be used | `string` | `""` | no |
-| nomad\_cluster\_name | The name of the Nomad cluster (e.g. nomad-servers-stage). This variable is used to namespace all resources created by this module. | `string` | `"nomad"` | no |
+| nomad\_cluster\_name | The name of the Nomad cluster. Only used if `nomad_server_cluster_name` or `nomad_client_cluster_name` is unused. `-server` is appended for server cluster and `-client` is append for client cluster | `string` | `"nomad"` | no |
+| nomad\_server\_cluster\_name | Overrides `nomad_cluster_name` if specified. The name of the Nomad server cluster. | `string` | n/a | yes |
 | nomad\_server\_instance\_type | Type of instances to deploy Nomad servers to | `string` | `"t2.medium"` | no |
 | nomad\_server\_lb\_deregistration\_delay | The time to wait for in-flight requests to complete while deregistering a target. During this time, the state of the target is draining. | `number` | `30` | no |
 | nomad\_server\_lb\_healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy (2-10). | `number` | `2` | no |

--- a/modules/core/nomad_clients.tf
+++ b/modules/core/nomad_clients.tf
@@ -2,6 +2,10 @@
 # DEPLOY THE NOMAD CLIENT NODES
 # --------------------------------------------------------------------------------------------------
 
+locals {
+  nomad_client_cluster_name = var.nomad_client_cluster_name != null ? var.nomad_client_cluster_name : "${var.nomad_cluster_name}-client"
+}
+
 module "nomad_clients" {
   source = "../nomad-clients"
 
@@ -13,7 +17,7 @@ module "nomad_clients" {
   allowed_inbound_cidr_blocks         = var.nomad_clients_allowed_inbound_cidr_blocks
   nomad_clients_services_inbound_cidr = var.nomad_clients_services_inbound_cidr
 
-  cluster_name  = "${var.nomad_cluster_name}-client"
+  cluster_name  = local.nomad_client_cluster_name
   instance_type = var.nomad_client_instance_type
 
   clients_min     = var.nomad_clients_min

--- a/modules/core/nomad_servers.tf
+++ b/modules/core/nomad_servers.tf
@@ -3,17 +3,18 @@
 # --------------------------------------------------------------------------------------------------
 
 locals {
-  nomad_server_http_port = 4646
-  nomad_server_user_data = coalesce(var.nomad_servers_user_data, data.template_file.user_data_nomad_server.rendered)
+  nomad_server_http_port    = 4646
+  nomad_server_user_data    = coalesce(var.nomad_servers_user_data, data.template_file.user_data_nomad_server.rendered)
+  nomad_server_cluster_name = var.nomad_server_cluster_name != null ? var.nomad_server_cluster_name : "${var.nomad_cluster_name}-server"
 }
 
 module "nomad_servers" {
   source  = "hashicorp/nomad/aws//modules/nomad-cluster"
   version = "0.7.1"
 
-  asg_name          = "${var.nomad_cluster_name}-server"
-  cluster_name      = "${var.nomad_cluster_name}-server"
-  cluster_tag_value = "${var.nomad_cluster_name}-server"
+  asg_name          = local.nomad_server_cluster_name
+  cluster_name      = local.nomad_server_cluster_name
+  cluster_tag_value = local.nomad_server_cluster_name
   instance_type     = var.nomad_server_instance_type
 
   # You should typically use a fixed size of 3 or 5 for your Nomad server cluster

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -141,8 +141,20 @@ variable "associate_public_ip_address" {
 }
 
 variable "nomad_cluster_name" {
-  description = "The name of the Nomad cluster (e.g. nomad-servers-stage). This variable is used to namespace all resources created by this module."
+  description = "The name of the Nomad cluster. Only used if `nomad_server_cluster_name` or `nomad_client_cluster_name` is unused. `-server` is appended for server cluster and `-client` is append for client cluster"
   default     = "nomad"
+}
+
+variable "nomad_server_cluster_name" {
+  description = "Overrides `nomad_cluster_name` if specified. The name of the Nomad server cluster."
+  type        = string
+  default     = null
+}
+
+variable "nomad_client_cluster_name" {
+  description = "Overrides `nomad_cluster_name` if specified. The name of the Nomad client cluster."
+  type        = string
+  default     = null
 }
 
 variable "nomad_server_instance_type" {


### PR DESCRIPTION
Names can be overridden by `nomad_server_cluster_name` and
`nomad_client_cluster_name`.