### PR TITLE
refactor(nomad): rework cidr acceptance

### DIFF
--- a/modules/core/INOUT.md
+++ b/modules/core/INOUT.md
@@ -52,11 +52,11 @@
 | nomad\_clients\_desired | The desired number of Nomad client nodes to deploy. | `number` | `6` | no |
 | nomad\_clients\_docker\_privileged | Flag to enable privileged mode for Docker driver on Nomad client | `bool` | `false` | no |
 | nomad\_clients\_docker\_volumes\_mounting | Flag to enable volume mounting for Docker driver on Nomad client | `bool` | `false` | no |
+| nomad\_clients\_dynamic\_ports\_inbound\_cidr\_blocks | A list of CIDR-formatted IP address ranges from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from. | `list(string)` | n/a | yes |
 | nomad\_clients\_max | The max number of Nomad client nodes to deploy. | `number` | `8` | no |
 | nomad\_clients\_min | The minimum number of Nomad client nodes to deploy. | `number` | `3` | no |
 | nomad\_clients\_root\_volume\_size | The size, in GB, of the root EBS volume. | `number` | `50` | no |
 | nomad\_clients\_root\_volume\_type | The type of volume. Must be one of: standard, gp2, or io1. | `string` | `"gp2"` | no |
-| nomad\_clients\_services\_inbound\_cidr | A list of CIDR-formatted IP address ranges (in addition to the VPC range) from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from. | `list(string)` | `[]` | no |
 | nomad\_clients\_user\_data | The user data for the Nomad clients EC2 instances. If set to empty, the default template will be used | `string` | `""` | no |
 | nomad\_cluster\_name | The name of the Nomad cluster. Only used if `nomad_server_cluster_name` or `nomad_client_cluster_name` is unused. `-server` is appended for server cluster and `-client` is append for client cluster | `string` | `"nomad"` | no |
 | nomad\_server\_cluster\_name | Overrides `nomad_cluster_name` if specified. The name of the Nomad server cluster. | `string` | n/a | yes |

--- a/modules/core/nomad_clients.tf
+++ b/modules/core/nomad_clients.tf
@@ -14,8 +14,8 @@ module "nomad_clients" {
   vpc_id         = var.vpc_id
   vpc_subnet_ids = var.nomad_client_subnets
 
-  allowed_inbound_cidr_blocks         = var.nomad_clients_allowed_inbound_cidr_blocks
-  nomad_clients_services_inbound_cidr = var.nomad_clients_services_inbound_cidr
+  allowed_inbound_cidr_blocks       = var.nomad_clients_allowed_inbound_cidr_blocks
+  dynamic_ports_inbound_cidr_blocks = var.nomad_clients_dynamic_ports_inbound_cidr_blocks
 
   cluster_name  = local.nomad_client_cluster_name
   instance_type = var.nomad_client_instance_type

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -197,10 +197,9 @@ variable "nomad_clients_max" {
   default     = 8
 }
 
-variable "nomad_clients_services_inbound_cidr" {
-  description = "A list of CIDR-formatted IP address ranges (in addition to the VPC range) from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from."
+variable "nomad_clients_dynamic_ports_inbound_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from."
   type        = list(string)
-  default     = []
 }
 
 variable "nomad_servers_root_volume_type" {

--- a/modules/nomad-clients/INOUT.md
+++ b/modules/nomad-clients/INOUT.md
@@ -22,11 +22,11 @@
 | consul\_cluster\_name | Name of the Consul cluster to deploy | `string` | `"consul-nomad-prototype"` | no |
 | docker\_privileged | Flag to enable privileged mode for Docker driver on Nomad client | `bool` | `false` | no |
 | docker\_volumes\_mounting | Flag to enable volume mounting for Docker driver on Nomad client | `bool` | `false` | no |
+| dynamic\_ports\_inbound\_cidr\_blocks | A list of CIDR-formatted IP address ranges from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from. | `list(string)` | n/a | yes |
 | iam\_permissions\_boundary | If set, restricts the created IAM role to the given permissions boundary | `string` | n/a | yes |
 | instance\_type | Type of instances to deploy Nomad servers to | `string` | `"t2.medium"` | no |
 | integration\_consul\_prefix | The Consul prefix used by the various integration scripts during initial instance boot. | `string` | `"terraform/"` | no |
 | integration\_service\_type | The 'server type' for this Nomad cluster. This is used in several integration.<br>If empty, this defaults to the `cluster_name` variable | `string` | `""` | no |
-| nomad\_clients\_services\_inbound\_cidr | A list of CIDR-formatted IP address ranges (in addition to the VPC range) from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from. | `list(string)` | `[]` | no |
 | root\_volume\_size | The size, in GB, of the root EBS volume. | `number` | `50` | no |
 | root\_volume\_type | The type of volume. Must be one of: standard, gp2, or io1. | `string` | `"gp2"` | no |
 | spot\_price | Spot price of EC2 instance | `string` | `""` | no |

--- a/modules/nomad-clients/main.tf
+++ b/modules/nomad-clients/main.tf
@@ -1,11 +1,5 @@
 locals {
-  allowed_inbound_cidr_blocks = concat(list(data.aws_vpc.selected.cidr_block), var.allowed_inbound_cidr_blocks)
-  services_inbound_cidr       = concat(list(data.aws_vpc.selected.cidr_block), var.nomad_clients_services_inbound_cidr)
-  user_data                   = coalesce(var.user_data, data.template_file.user_data_nomad_client.rendered)
-}
-
-data "aws_vpc" "selected" {
-  id = var.vpc_id
+  user_data = coalesce(var.user_data, data.template_file.user_data_nomad_client.rendered)
 }
 
 # --------------------------------------------------------------------------------------------------
@@ -36,7 +30,7 @@ module "nomad_clients" {
   subnet_ids = var.vpc_subnet_ids
 
   ssh_key_name                = var.ssh_key_name
-  allowed_inbound_cidr_blocks = local.allowed_inbound_cidr_blocks
+  allowed_inbound_cidr_blocks = var.dynamic_ports_inbound_cidr_blocks
   allowed_ssh_cidr_blocks     = var.allowed_ssh_cidr_blocks
   associate_public_ip_address = var.associate_public_ip_address
 
@@ -83,7 +77,7 @@ resource "aws_security_group_rule" "nomad_client_services_tcp" {
   from_port         = 20000
   to_port           = 32000
   protocol          = "tcp"
-  cidr_blocks       = local.services_inbound_cidr
+  cidr_blocks       = var.dynamic_ports_inbound_cidr_blocks
 }
 
 resource "aws_security_group_rule" "nomad_client_services_udp" {
@@ -92,5 +86,5 @@ resource "aws_security_group_rule" "nomad_client_services_udp" {
   from_port         = 20000
   to_port           = 32000
   protocol          = "udp"
-  cidr_blocks       = local.services_inbound_cidr
+  cidr_blocks       = var.dynamic_ports_inbound_cidr_blocks
 }

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -56,10 +56,9 @@ variable "spot_price" {
   default     = ""
 }
 
-variable "nomad_clients_services_inbound_cidr" {
-  description = "A list of CIDR-formatted IP address ranges (in addition to the VPC range) from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from."
+variable "dynamic_ports_inbound_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges from which the services hosted on Nomad clients on ports 20000 to 32000 will accept connections from."
   type        = list(string)
-  default     = []
 }
 
 variable "user_data" {


### PR DESCRIPTION
No longer assume the first VPC CIDR block is the right one to include.

Instead force the user to manual key in the CIDR blocks to allow.

BREAKING CHANGE: Var name change + remove assumption of always including VPC's
only CIDR for Nomad dynamic ports access.