### PR TITLE
feat(elasticsearch): add Consul service health check

### DIFF
--- a/modules/elasticsearch_post/consul.tf
+++ b/modules/elasticsearch_post/consul.tf
@@ -7,4 +7,15 @@ resource "consul_service" "es" {
   node = consul_node.es.name
   name = var.es_consul_service
   port = var.es_default_access["port"]
+
+  check {
+    check_id                          = "service:elasticsearch"
+    name                              = "Elasticsearch cluster health check"
+    status                            = "passing"
+    http                              = "https://${var.es_endpoint}/_cluster/health"
+    tls_skip_verify                   = false
+    interval                          = "30s"
+    timeout                           = "10s"
+    deregister_critical_service_after = "600s"
+  }
 }

--- a/modules/elasticsearch_post/consul.tf
+++ b/modules/elasticsearch_post/consul.tf
@@ -1,19 +1,25 @@
 resource "consul_node" "es" {
   name    = var.es_consul_service
   address = var.es_endpoint
+
+  meta = {
+    "external-node"  = "true"
+    "external-probe" = "true"
+  }
 }
 
 resource "consul_service" "es" {
   node = consul_node.es.name
   name = var.es_consul_service
   port = var.es_default_access["port"]
+  tags = ["elasticsearch"]
 
   check {
     check_id                          = "service:elasticsearch"
     name                              = "Elasticsearch cluster health check"
     status                            = "passing"
-    http                              = "https://${var.es_endpoint}/_cluster/health"
-    tls_skip_verify                   = false
+    http                              = "${var.es_endpoint}/_cluster/health"
+    method                            = "GET"
     interval                          = "30s"
     timeout                           = "10s"
     deregister_critical_service_after = "600s"


### PR DESCRIPTION
Add meta and touch up settings to allow Consul ESM to operate if available.