### PR TITLE
fix(fluentd): use TF variables for CPU/mem resource in jobspec

### DIFF
--- a/modules/fluentd/INOUT.md
+++ b/modules/fluentd/INOUT.md
@@ -22,9 +22,11 @@
 | es6\_support | Set to `true` if you are using Elasticsearch 6 and above to support the removal of mapping types (https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html) | `bool` | `false` | no |
 | fluentd\_conf\_file | Rendered fluentd configuration file | `string` | `"alloc/config/fluent.conf"` | no |
 | fluentd\_count | Number of copies of Fluentd to run | `number` | `3` | no |
+| fluentd\_cpu | CPU resource assigned to the fluentd job | `number` | `3000` | no |
 | fluentd\_force\_pull | Force pull an image. Useful if the tag is mutable. | `string` | `"false"` | no |
 | fluentd\_image | Docker image for fluentd | `string` | `"govtechsg/fluentd-s3-elasticsearch"` | no |
 | fluentd\_match | Tags that fluentd should output to S3 and Elasticsearch | `string` | `"@ERROR app.** docker.** services.** system.** vault**"` | no |
+| fluentd\_memory | Memory resource assigned to the fluentd job | `number` | `512` | no |
 | fluentd\_port | Port on the Docker image in which the TCP interface is exposed | `number` | `4224` | no |
 | fluentd\_tag | Tag for fluentd Docker image | `string` | `"1.2.5-latest"` | no |
 | inject\_source\_host | Inject the log source host name and address into the logs | `bool` | `true` | no |

--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -46,6 +46,8 @@ data "template_file" "fluentd_jobspec" {
     fluentd_image      = var.fluentd_image
     fluentd_tag        = var.fluentd_tag
     fluentd_force_pull = var.fluentd_force_pull
+    fluentd_cpu        = var.fluentd_cpu
+    fluentd_memory     = var.fluentd_memory
 
     fluentd_conf_template = data.template_file.fluentd_tf_rendered_conf.rendered
     fluentd_conf_file     = var.fluentd_conf_file

--- a/modules/fluentd/templates/fluentd.nomad
+++ b/modules/fluentd/templates/fluentd.nomad
@@ -102,8 +102,8 @@ EOH
       }
 
       resources {
-        cpu    = 3000
-        memory = 512
+        cpu    = ${var.fluentd_cpu}
+        memory = ${var.fluentd_memory}
 
         network {
           mbits = 100

--- a/modules/fluentd/variables.tf
+++ b/modules/fluentd/variables.tf
@@ -70,6 +70,16 @@ variable "additional_blocks" {
   default     = ""
 }
 
+variable "fluentd_cpu" {
+  description = "CPU resource assigned to the fluentd job"
+  default = 3000
+}
+
+variable "fluentd_memory" {
+  description = "Memory resource assigned to the fluentd job"
+  default = 512
+}
+
 #############################
 # Vault related
 #############################

--- a/modules/fluentd/variables.tf
+++ b/modules/fluentd/variables.tf
@@ -72,12 +72,12 @@ variable "additional_blocks" {
 
 variable "fluentd_cpu" {
   description = "CPU resource assigned to the fluentd job"
-  default = 3000
+  default     = 3000
 }
 
 variable "fluentd_memory" {
   description = "Memory resource assigned to the fluentd job"
-  default = 512
+  default     = 512
 }
 
 #############################


### PR DESCRIPTION
Update fluentd jobspec to use Terraform variables with the same default value, for flexibility in setting the compute/memory resource for the fluentd job