### PR TITLE
fix(fluentd): fix incorrect interpolation syntax

### DIFF
--- a/modules/fluentd/templates/fluentd.nomad
+++ b/modules/fluentd/templates/fluentd.nomad
@@ -102,8 +102,8 @@ EOH
       }
 
       resources {
-        cpu    = ${var.fluentd_cpu}
-        memory = ${var.fluentd_memory}
+        cpu    = ${fluentd_cpu}
+        memory = ${fluentd_memory}
 
         network {
           mbits = 100


### PR DESCRIPTION
FIx incorrect interpolation syntax in the Nomad jobspec, causing the jobspec to fail to render