### PR TITLE
chore: support weekly fluent indexes

### DIFF
--- a/modules/fluentd/INOUT.md
+++ b/modules/fluentd/INOUT.md
@@ -48,6 +48,7 @@
 | vault\_address | Vault server address for custom execution of commands, required if `vault_sts_iam_permissions_boundary` is set | `string` | `""` | no |
 | vault\_sts\_iam\_permissions\_boundary | Optional IAM policy as permissions boundary for STS generated IAM user | `string` | `""` | no |
 | vault\_sts\_path | If logging to S3 is enabled, provide to the path in Vault in which the AWS Secrets Engine is mounted | `string` | `""` | no |
+| weekly\_index\_enabled | Enable weekly indexing strategy for Fluentd Elasticsearch plugin. If disabled, default indexing strategy is daily. | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/fluentd/consul.tf
+++ b/modules/fluentd/consul.tf
@@ -1,10 +1,11 @@
 locals {
-  file_logging_consul_key  = "${var.consul_key_prefix}fluentd/log_to_file"
-  fluentd_match_consul_key = "${var.consul_key_prefix}fluentd/match"
-  s3_consul_key            = "${var.consul_key_prefix}fluentd/log_to_s3"
-  inject_source_host       = "${var.consul_key_prefix}fluentd/inject_source_host"
-  source_address_key       = "${var.consul_key_prefix}fluentd/source_address_key"
-  source_hostname_key      = "${var.consul_key_prefix}fluentd/source_hostname_key"
+  weekly_index_enabled_consul_key = "${var.consul_key_prefix}fluentd/weekly_index_enabled"
+  file_logging_consul_key         = "${var.consul_key_prefix}fluentd/log_to_file"
+  fluentd_match_consul_key        = "${var.consul_key_prefix}fluentd/match"
+  s3_consul_key                   = "${var.consul_key_prefix}fluentd/log_to_s3"
+  inject_source_host              = "${var.consul_key_prefix}fluentd/inject_source_host"
+  source_address_key              = "${var.consul_key_prefix}fluentd/source_address_key"
+  source_hostname_key             = "${var.consul_key_prefix}fluentd/source_hostname_key"
 }
 
 resource "consul_keys" "readme" {
@@ -64,6 +65,14 @@ resource "consul_keys" "source_hostname_key" {
   key {
     path   = local.source_hostname_key
     value  = var.inject_source_host ? var.source_hostname_key : ""
+    delete = true
+  }
+}
+
+resource "consul_keys" "weekly_index_enabled" {
+  key {
+    path   = local.s3_consul_key
+    value  = var.weekly_index_enabled ? "true" : "false"
     delete = true
   }
 }

--- a/modules/fluentd/consul.tf
+++ b/modules/fluentd/consul.tf
@@ -71,7 +71,7 @@ resource "consul_keys" "source_hostname_key" {
 
 resource "consul_keys" "weekly_index_enabled" {
   key {
-    path   = local.s3_consul_key
+    path   = local.weekly_index_enabled_consul_key
     value  = var.weekly_index_enabled ? "true" : "false"
     delete = true
   }

--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -15,6 +15,7 @@ data "template_file" "fluentd_tf_rendered_conf" {
 
     file_logging_consul_key         = local.file_logging_consul_key
     fluentd_match_consul_key        = local.fluentd_match_consul_key
+    s3_consul_key                   = local.s3_consul_key
     weekly_index_enabled_consul_key = local.weekly_index_enabled_consul_key
 
     inject_source_host  = local.inject_source_host

--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -13,9 +13,9 @@ data "template_file" "fluentd_tf_rendered_conf" {
     s3_prefix     = "logs/"
     storage_class = var.logs_s3_storage_class
 
-    file_logging_consul_key  = local.file_logging_consul_key
-    fluentd_match_consul_key = local.fluentd_match_consul_key
-    s3_consul_key            = local.s3_consul_key
+    file_logging_consul_key         = local.file_logging_consul_key
+    fluentd_match_consul_key        = local.fluentd_match_consul_key
+    weekly_index_enabled_consul_key = local.weekly_index_enabled_consul_key
 
     inject_source_host  = local.inject_source_host
     source_address_key  = local.source_address_key

--- a/modules/fluentd/templates/fluent.conf
+++ b/modules/fluentd/templates/fluent.conf
@@ -76,7 +76,7 @@
     logstash_format true
     logstash_prefix "$${tag}"
     {{ if eq (keyOrDefault "${weekly_index_enabled_consul_key}" "false") "true" }}
-    logstash_prefix %xxxx.%ww
+    logstash_dateformat %G.W%V
     {{ end }}
 
     # Mapping types are removed:

--- a/modules/fluentd/templates/fluent.conf
+++ b/modules/fluentd/templates/fluent.conf
@@ -76,7 +76,7 @@
     logstash_format true
     logstash_prefix "$${tag}"
     {{ if eq (keyOrDefault "${weekly_index_enabled_consul_key}" "false") "true" }}
-    logstash_prefix "xxxx.ww"
+    logstash_prefix %xxxx.%ww
     {{ end }}
 
     # Mapping types are removed:

--- a/modules/fluentd/templates/fluent.conf
+++ b/modules/fluentd/templates/fluent.conf
@@ -69,11 +69,15 @@
     @type elasticsearch
     host ${elasticsearch_hostname}
     scheme https
-    logstash_format true
-    logstash_prefix "$${tag}"
     port ${elasticsearch_port}
     flush_interval 5s
     include_tag_key true
+
+    logstash_format true
+    logstash_prefix "$${tag}"
+    {{ if eq (keyOrDefault "${weekly_index_enabled_consul_key}" "false") "true" }}
+    logstash_prefix "xxxx.ww"
+    {{ end }}
 
     # Mapping types are removed:
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html

--- a/modules/fluentd/variables.tf
+++ b/modules/fluentd/variables.tf
@@ -153,6 +153,11 @@ variable "inject_source_host" {
   default     = true
 }
 
+variable "weekly_index_enabled" {
+  description = "Enable weekly indexing strategy for Fluentd Elasticsearch plugin. If disabled, default indexing strategy is daily."
+  default     = true
+}
+
 variable "source_address_key" {
   description = "Key to inject the source address to"
   default     = "host"


### PR DESCRIPTION
Change Elasticsearch indexing strategy from daily to weekly for applications piping their logs to fluentd. 

```
# old index
docker.traefik-2022.01.06

# new
docker.traefik-2022.w01
```

https://github.com/uken/fluent-plugin-elasticsearch/#logstash_dateformat