### PR TITLE
fix(nexus): update to `bound_iam_role_arns`

### DIFF
--- a/modules/nexus/aws_auth.tf
+++ b/modules/nexus/aws_auth.tf
@@ -1,12 +1,12 @@
 resource "vault_aws_auth_backend_role" "nexus" {
   count = var.aws_auth_enabled ? 1 : 0
 
-  backend            = var.aws_auth_path
-  role               = var.aws_auth_vault_role
-  auth_type          = "ec2"
-  bound_iam_role_arn = aws_iam_role.nexus.arn
-  token_policies     = var.aws_auth_policies
-  token_period       = var.aws_auth_period_minutes
+  backend             = var.aws_auth_path
+  role                = var.aws_auth_vault_role
+  auth_type           = "ec2"
+  bound_iam_role_arns = [aws_iam_role.nexus.arn]
+  token_policies      = var.aws_auth_policies
+  token_period        = var.aws_auth_period_minutes
 }
 
 resource "consul_keys" "aws_auth" {


### PR DESCRIPTION
Ref:
https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/version_2_upgrade#deprecated-fields-have-been-removed