### PR TITLE
chore(alb): default to drop invalid headers

### DIFF
--- a/modules/core/INOUT.md
+++ b/modules/core/INOUT.md
@@ -39,6 +39,7 @@
 | iam\_permissions\_boundary | If set, restricts the created IAM role to the given permissions boundary | `string` | n/a | yes |
 | integration\_consul\_prefix | The Consul prefix used by the various integration scripts during initial instance boot. | `string` | `"terraform/"` | no |
 | internal\_lb\_certificate\_arn | ARN of the certificate to use for the internal LB | `any` | n/a | yes |
+| internal\_lb\_drop\_invalid\_header\_fields | Set to true for internal load balancer to drop invalid header fields | `bool` | `true` | no |
 | internal\_lb\_incoming\_cidr | A list of CIDR-formatted IP address ranges from which the internal Load balancer is allowed to listen to | `list(string)` | n/a | yes |
 | internal\_lb\_name | Name of the internal load balancer | `string` | `"internal"` | no |
 | internal\_lb\_subnets | List of subnets to deploy the internal LB to | `list(string)` | n/a | yes |

--- a/modules/core/elb.tf
+++ b/modules/core/elb.tf
@@ -21,6 +21,8 @@ resource "aws_lb" "internal" {
     prefix  = var.elb_access_log_prefix
   }
 
+  drop_invalid_header_fields = var.internal_lb_drop_invalid_header_fields
+
   tags = merge(var.tags, { Name = var.internal_lb_name })
 }
 

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -91,6 +91,11 @@ variable "internal_lb_incoming_cidr" {
   type        = list(string)
 }
 
+variable "internal_lb_drop_invalid_header_fields" {
+  description = "Set to true for internal load balancer to drop invalid header fields"
+  default     = true
+}
+
 # --------------------------------------------------------------------------------------------------
 # Domain name variables
 # --------------------------------------------------------------------------------------------------

--- a/modules/traefik/INOUT.md
+++ b/modules/traefik/INOUT.md
@@ -17,11 +17,13 @@
 | deregistration\_delay | Time before an unhealthy Elastic Load Balancer target becomes removed | `number` | `60` | no |
 | elb\_ssl\_policy | ELB SSL policy for HTTPs listeners. See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html | `string` | `"ELBSecurityPolicy-TLS-1-2-2017-01"` | no |
 | external\_certificate\_arn | ARN for the certificate to use for the external LB | `any` | n/a | yes |
+| external\_drop\_invalid\_header\_fields | Set to true for external Nomad load balancer to drop invalid header fields | `bool` | `true` | no |
 | external\_lb\_incoming\_cidr | A list of CIDR-formatted IP address ranges from which the external Load balancer is allowed to listen to | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]<br></pre> | no |
 | external\_lb\_name | Name of the external Nomad load balancer | `string` | `"traefik-external"` | no |
 | external\_nomad\_clients\_asg | The Nomad Clients Autoscaling group to attach the external load balancer to | `any` | n/a | yes |
 | healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy (2-10). | `number` | `2` | no |
 | internal\_certificate\_arn | ARN for the certificate to use for the internal LB | `any` | n/a | yes |
+| internal\_drop\_invalid\_header\_fields | Set to true for internal Nomad load balancer to drop invalid header fields | `bool` | `true` | no |
 | internal\_lb\_incoming\_cidr | A list of CIDR-formatted IP address ranges from which the internal load balancer is allowed to listen to | `list(string)` | `[]` | no |
 | internal\_lb\_name | Name of the external Nomad load balancer | `string` | `"traefik-internal"` | no |
 | internal\_nomad\_clients\_asg | The Nomad Clients Autoscaling group to attach the internal load balancer to | `any` | n/a | yes |

--- a/modules/traefik/external.tf
+++ b/modules/traefik/external.tf
@@ -13,6 +13,8 @@ resource "aws_lb" "external" {
     prefix  = var.lb_external_access_log_prefix
   }
 
+  drop_invalid_header_fields = var.external_drop_invalid_header_fields
+
   tags = merge(var.tags, { Name = var.external_lb_name })
 }
 

--- a/modules/traefik/internal.tf
+++ b/modules/traefik/internal.tf
@@ -14,6 +14,8 @@ resource "aws_lb" "internal" {
     prefix  = var.lb_internal_access_log_prefix
   }
 
+  drop_invalid_header_fields = var.internal_drop_invalid_header_fields
+
   tags = merge(var.tags, { Name = var.internal_lb_name })
 }
 

--- a/modules/traefik/variables.tf
+++ b/modules/traefik/variables.tf
@@ -65,9 +65,19 @@ variable "external_lb_name" {
   default     = "traefik-external"
 }
 
+variable "external_drop_invalid_header_fields" {
+  description = "Set to true for external Nomad load balancer to drop invalid header fields"
+  default     = true
+}
+
 variable "internal_lb_name" {
   description = "Name of the external Nomad load balancer"
   default     = "traefik-internal"
+}
+
+variable "internal_drop_invalid_header_fields" {
+  description = "Set to true for internal Nomad load balancer to drop invalid header fields"
+  default     = true
 }
 
 variable "tags" {


### PR DESCRIPTION
This is to default to good security practices.