### PR TITLE
chore(lb): add option to disable load balancer HTTP listener

### DIFF
--- a/modules/core/INOUT.md
+++ b/modules/core/INOUT.md
@@ -36,6 +36,7 @@
 | elb\_access\_log\_prefix | Prefix in the S3 bucket to log internal LB access | `string` | `""` | no |
 | elb\_idle\_timeout | The time in seconds that the connection is allowed to be idle. Consul supports blocking requests that can last up to 600 seconds. Increase this to support that. | `number` | `660` | no |
 | elb\_ssl\_policy | ELB SSL policy for HTTPs listeners. See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html | `string` | `"ELBSecurityPolicy-TLS-1-2-2017-01"` | no |
+| enable\_http | Set to true to enable HTTP listener that redirects to HTTPS. Defaults to true | `bool` | `true` | no |
 | iam\_permissions\_boundary | If set, restricts the created IAM role to the given permissions boundary | `string` | n/a | yes |
 | integration\_consul\_prefix | The Consul prefix used by the various integration scripts during initial instance boot. | `string` | `"terraform/"` | no |
 | internal\_lb\_certificate\_arn | ARN of the certificate to use for the internal LB | `any` | n/a | yes |

--- a/modules/core/elb.tf
+++ b/modules/core/elb.tf
@@ -27,6 +27,8 @@ resource "aws_lb" "internal" {
 }
 
 resource "aws_lb_listener" "internal_http" {
+  count = var.enable_http ? 1 : 0
+
   load_balancer_arn = aws_lb.internal.arn
   port              = "80"
   protocol          = "HTTP"

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -86,6 +86,11 @@ variable "add_private_route53_zone" {
   default     = false
 }
 
+variable "enable_http" {
+  description = "Set to true to enable HTTP listener that redirects to HTTPS. Defaults to true"
+  default     = true
+}
+
 variable "internal_lb_incoming_cidr" {
   description = "A list of CIDR-formatted IP address ranges from which the internal Load balancer is allowed to listen to"
   type        = list(string)

--- a/modules/traefik/INOUT.md
+++ b/modules/traefik/INOUT.md
@@ -18,12 +18,14 @@
 | elb\_ssl\_policy | ELB SSL policy for HTTPs listeners. See https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html | `string` | `"ELBSecurityPolicy-TLS-1-2-2017-01"` | no |
 | external\_certificate\_arn | ARN for the certificate to use for the external LB | `any` | n/a | yes |
 | external\_drop\_invalid\_header\_fields | Set to true for external Nomad load balancer to drop invalid header fields | `bool` | `true` | no |
+| external\_enable\_http | Set to true to enable external HTTP listener that redirects to HTTPS. Defaults to true | `bool` | `true` | no |
 | external\_lb\_incoming\_cidr | A list of CIDR-formatted IP address ranges from which the external Load balancer is allowed to listen to | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]<br></pre> | no |
 | external\_lb\_name | Name of the external Nomad load balancer | `string` | `"traefik-external"` | no |
 | external\_nomad\_clients\_asg | The Nomad Clients Autoscaling group to attach the external load balancer to | `any` | n/a | yes |
 | healthy\_threshold | The number of consecutive health checks successes required before considering an unhealthy target healthy (2-10). | `number` | `2` | no |
 | internal\_certificate\_arn | ARN for the certificate to use for the internal LB | `any` | n/a | yes |
 | internal\_drop\_invalid\_header\_fields | Set to true for internal Nomad load balancer to drop invalid header fields | `bool` | `true` | no |
+| internal\_enable\_http | Set to true to enable internal HTTP listener that redirects to HTTPS. Defaults to true | `bool` | `true` | no |
 | internal\_lb\_incoming\_cidr | A list of CIDR-formatted IP address ranges from which the internal load balancer is allowed to listen to | `list(string)` | `[]` | no |
 | internal\_lb\_name | Name of the external Nomad load balancer | `string` | `"traefik-internal"` | no |
 | internal\_nomad\_clients\_asg | The Nomad Clients Autoscaling group to attach the internal load balancer to | `any` | n/a | yes |

--- a/modules/traefik/external.tf
+++ b/modules/traefik/external.tf
@@ -99,6 +99,8 @@ resource "aws_security_group_rule" "nomad_external_health_check_ingress" {
 #####################
 
 resource "aws_lb_listener" "http_external" {
+  count = var.external_enable_http ? 1 : 0
+
   load_balancer_arn = aws_lb.external.arn
   port              = "80"
   protocol          = "HTTP"

--- a/modules/traefik/internal.tf
+++ b/modules/traefik/internal.tf
@@ -134,6 +134,8 @@ resource "aws_autoscaling_attachment" "internal" {
 }
 
 resource "aws_lb_listener" "internal_http" {
+  count = var.internal_enable_http ? 1 : 0
+
   load_balancer_arn = aws_lb.internal.arn
   port              = "80"
   protocol          = "HTTP"

--- a/modules/traefik/variables.tf
+++ b/modules/traefik/variables.tf
@@ -60,6 +60,11 @@ variable "internal_nomad_clients_asg" {
 # Optional Variables
 #########################################
 
+variable "external_enable_http" {
+  description = "Set to true to enable external HTTP listener that redirects to HTTPS. Defaults to true"
+  default     = true
+}
+
 variable "external_lb_name" {
   description = "Name of the external Nomad load balancer"
   default     = "traefik-external"
@@ -67,6 +72,11 @@ variable "external_lb_name" {
 
 variable "external_drop_invalid_header_fields" {
   description = "Set to true for external Nomad load balancer to drop invalid header fields"
+  default     = true
+}
+
+variable "internal_enable_http" {
+  description = "Set to true to enable internal HTTP listener that redirects to HTTPS. Defaults to true"
   default     = true
 }
 


### PR DESCRIPTION
Still defaults to `true` by default to prevent breaking changes.