### PR TITLE
chore(core): add config for additional security group IDs 

### DIFF
--- a/modules/core/INOUT.md
+++ b/modules/core/INOUT.md
@@ -16,6 +16,7 @@
 | client\_node\_class | Nomad Client Node Class name for cluster identification | `string` | `"nomad-client"` | no |
 | cluster\_tag\_key | The tag the Consul EC2 Instances will look for to automatically discover each other and form a cluster. | `string` | `"consul-servers"` | no |
 | consul\_allowed\_inbound\_cidr\_blocks | A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Consul servers for API usage | `list(string)` | n/a | yes |
+| consul\_allowed\_inbound\_security\_group\_ids | A list of security group IDs that will be allowed to connect to Consul Servers | `list(string)` | `[]` | no |
 | consul\_ami\_id | AMI ID for Consul servers | `any` | n/a | yes |
 | consul\_api\_domain | Domain to access Consul HTTP API | `any` | n/a | yes |
 | consul\_cluster\_name | Name of the Consul cluster to deploy | `string` | `"consul"` | no |
@@ -45,6 +46,7 @@
 | internal\_lb\_name | Name of the internal load balancer | `string` | `"internal"` | no |
 | internal\_lb\_subnets | List of subnets to deploy the internal LB to | `list(string)` | n/a | yes |
 | nomad\_api\_domain | Domain to access Nomad REST API | `any` | n/a | yes |
+| nomad\_client\_allowed\_inbound\_security\_group\_ids | A list of security group IDs that will be allowed to connect to Nomad Clients | `list(string)` | `[]` | no |
 | nomad\_client\_cluster\_name | Overrides `nomad_cluster_name` if specified. The name of the Nomad client cluster. | `string` | n/a | yes |
 | nomad\_client\_instance\_type | Type of instances to deploy Nomad servers to | `string` | `"t2.medium"` | no |
 | nomad\_client\_subnets | List of subnets to launch Nomad clients in | `list(string)` | n/a | yes |
@@ -61,6 +63,7 @@
 | nomad\_clients\_root\_volume\_type | The type of volume. Must be one of: standard, gp2, or io1. | `string` | `"gp2"` | no |
 | nomad\_clients\_user\_data | The user data for the Nomad clients EC2 instances. If set to empty, the default template will be used | `string` | `""` | no |
 | nomad\_cluster\_name | The name of the Nomad cluster. Only used if `nomad_server_cluster_name` or `nomad_client_cluster_name` is unused. `-server` is appended for server cluster and `-client` is append for client cluster | `string` | `"nomad"` | no |
+| nomad\_server\_allowed\_inbound\_security\_group\_ids | A list of security group IDs that will be allowed to connect to Nomad Server | `list(string)` | `[]` | no |
 | nomad\_server\_cluster\_name | Overrides `nomad_cluster_name` if specified. The name of the Nomad server cluster. | `string` | n/a | yes |
 | nomad\_server\_instance\_type | Type of instances to deploy Nomad servers to | `string` | `"t2.medium"` | no |
 | nomad\_server\_lb\_deregistration\_delay | The time to wait for in-flight requests to complete while deregistering a target. During this time, the state of the target is draining. | `number` | `30` | no |

--- a/modules/core/consul.tf
+++ b/modules/core/consul.tf
@@ -38,6 +38,8 @@ module "consul_servers" {
   termination_policies = var.consul_termination_policies
 
   iam_permissions_boundary = var.iam_permissions_boundary
+
+  additional_security_group_ids = var.allowed_inbound_security_group_ids
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/core/consul.tf
+++ b/modules/core/consul.tf
@@ -39,7 +39,7 @@ module "consul_servers" {
 
   iam_permissions_boundary = var.iam_permissions_boundary
 
-  additional_security_group_ids = var.allowed_inbound_security_group_ids
+  additional_security_group_ids = var.consul_allowed_inbound_security_group_ids
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/core/nomad_clients.tf
+++ b/modules/core/nomad_clients.tf
@@ -44,4 +44,6 @@ module "nomad_clients" {
   termination_policies = var.nomad_client_termination_policies
 
   iam_permissions_boundary = var.iam_permissions_boundary
+
+  additional_security_group_ids = var.nomad_client_allowed_inbound_security_group_ids
 }

--- a/modules/core/nomad_servers.tf
+++ b/modules/core/nomad_servers.tf
@@ -41,6 +41,8 @@ module "nomad_servers" {
   termination_policies = var.nomad_server_termination_policies
 
   iam_permissions_boundary = var.iam_permissions_boundary
+
+  security_groups = var.nomad_server_allowed_inbound_security_group_ids
 }
 
 # --------------------------------------------------------------------------------------------------

--- a/modules/core/variables.tf
+++ b/modules/core/variables.tf
@@ -187,9 +187,21 @@ variable "nomad_server_termination_policies" {
   default     = "NewestInstance"
 }
 
+variable "nomad_server_allowed_inbound_security_group_ids" {
+  description = "A list of security group IDs that will be allowed to connect to Nomad Server"
+  type        = list(string)
+  default     = []
+}
+
 variable "nomad_client_termination_policies" {
   description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default."
   default     = "Default"
+}
+
+variable "nomad_client_allowed_inbound_security_group_ids" {
+  description = "A list of security group IDs that will be allowed to connect to Nomad Clients"
+  type        = list(string)
+  default     = []
 }
 
 variable "nomad_clients_min" {
@@ -448,6 +460,12 @@ variable "consul_lb_unhealthy_threshold" {
 variable "consul_lb_interval" {
   description = "The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds."
   default     = 30
+}
+
+variable "consul_allowed_inbound_security_group_ids" {
+  description = "A list of security group IDs that will be allowed to connect to Consul Servers"
+  type        = list(string)
+  default     = []
 }
 
 variable "vault_lb_deregistration_delay" {

--- a/modules/nomad-clients/INOUT.md
+++ b/modules/nomad-clients/INOUT.md
@@ -9,6 +9,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| additional\_security\_group\_ids | A list of security group IDs that will be allowed to connect to Consul Servers | `list(string)` | `[]` | no |
 | allowed\_inbound\_cidr\_blocks | A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Nomad Clients for API usage | `list(string)` | n/a | yes |
 | allowed\_ssh\_cidr\_blocks | A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow SSH connections | `list(string)` | `[]` | no |
 | ami\_id | AMI ID for Nomad clients | `any` | n/a | yes |

--- a/modules/nomad-clients/main.tf
+++ b/modules/nomad-clients/main.tf
@@ -37,6 +37,9 @@ module "nomad_clients" {
   termination_policies = var.termination_policies
 
   iam_permissions_boundary = var.iam_permissions_boundary
+
+  security_groups = var.additional_security_group_ids
+
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/nomad-clients/variables.tf
+++ b/modules/nomad-clients/variables.tf
@@ -131,6 +131,12 @@ variable "iam_permissions_boundary" {
   default     = null
 }
 
+variable "additional_security_group_ids" {
+  description = "A list of security group IDs that will be allowed to connect to Consul Servers"
+  type        = list(string)
+  default     = []
+}
+
 # --------------------------------------------------------------------------------------------------
 # Post Bootstrap Integration Parameters
 # These parameters are used in conjunction with the other modules in this repository.


### PR DESCRIPTION
Allow Consul & Nomad modules to take in Additional Security Group IDs

This is to allow additional Security Groups to be attached to the core services as needed