### PR TITLE
chore(vault): use `permissions_boundary_arn`

### DIFF
--- a/modules/fluentd/INOUT.md
+++ b/modules/fluentd/INOUT.md
@@ -5,9 +5,8 @@
 | aws | >= 2.42, < 4.0.0 |
 | consul | >= 2.5 |
 | nomad | >= 1.4 |
-| null | n/a |
 | template | ~> 2.0 |
-| vault | >= 2.0 |
+| vault | >= 3.8.0 |
 
 ## Inputs
 
@@ -46,7 +45,7 @@
 | source\_hostname\_key | Key to inject the source hostname to | `string` | `"hostname"` | no |
 | tags | Tags to apply to resources | `map` | <pre>{<br>  "Terraform": "true"<br>}<br></pre> | no |
 | vault\_address | Vault server address for custom execution of commands, required if `vault_sts_iam_permissions_boundary` is set | `string` | `""` | no |
-| vault\_sts\_iam\_permissions\_boundary | Optional IAM policy as permissions boundary for STS generated IAM user | `string` | `""` | no |
+| vault\_sts\_iam\_permissions\_boundary | Optional IAM policy as permissions boundary for STS generated IAM user | `string` | n/a | yes |
 | vault\_sts\_path | If logging to S3 is enabled, provide to the path in Vault in which the AWS Secrets Engine is mounted | `string` | `""` | no |
 | weekly\_index\_enabled | Enable weekly indexing strategy for Fluentd Elasticsearch plugin. If disabled, default indexing strategy is daily. | `bool` | `true` | no |
 

--- a/modules/fluentd/variables.tf
+++ b/modules/fluentd/variables.tf
@@ -97,7 +97,7 @@ variable "vault_sts_path" {
 variable "vault_sts_iam_permissions_boundary" {
   description = "Optional IAM policy as permissions boundary for STS generated IAM user"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "log_vault_role" {

--- a/modules/fluentd/vault.tf
+++ b/modules/fluentd/vault.tf
@@ -7,23 +7,8 @@ resource "vault_aws_secret_backend_role" "logs" {
   backend = var.vault_sts_path
 
   policy_arns = [aws_iam_policy.logs_s3[0].arn]
-}
-
-resource "null_resource" "logs_permissions_boundary" {
-  depends_on = [vault_aws_secret_backend_role.logs]
-
-  count = var.logs_s3_enabled && var.vault_sts_iam_permissions_boundary != "" ? 1 : 0
-
-  # Permissions boundary workaround
-  # https://github.com/terraform-providers/terraform-provider-vault/pull/781#issuecomment-656696212
-  # Requires both vault server + host vault CLI to be >= 1.3
-  provisioner "local-exec" {
-    command = <<EOF
-vault write -address="${var.vault_address}" \
-"${var.vault_sts_path}/roles/${var.log_vault_role}" \
-permissions_boundary_arn="${var.vault_sts_iam_permissions_boundary}"
-EOF
-  }
+  # When var.vault_sts_iam_permissions_boundary is null, this optional property is not set
+  permissions_boundary_arn = var.vault_sts_iam_permissions_boundary
 }
 
 resource "vault_policy" "logs" {

--- a/modules/fluentd/versions.tf
+++ b/modules/fluentd/versions.tf
@@ -17,7 +17,7 @@ terraform {
 
     vault = {
       source  = "hashicorp/vault"
-      version = ">= 2.0"
+      version = ">= 3.8.0"
     }
 
     # See: https://github.com/terraform-providers/terraform-provider-template/blob/v2.0.0/CHANGELOG.md#200-january-14-2019


### PR DESCRIPTION
Remove previous workaround since now permissions_boundary_arn is [supported](https://registry.terraform.io/providers/hashicorp/vault/3.8.0/docs/resources/aws_secret_backend_role#permissions_boundary_arn).

Since the attribute is optional, setting the default to null will cause terraform to [omit it](https://www.terraform.io/language/functions/defaults), same as the previous behaviour.