### PR TITLE
feat(fluentd):  Add support for Cloudwatch Logging

### DIFF
--- a/modules/fluentd/INOUT.md
+++ b/modules/fluentd/INOUT.md
@@ -33,7 +33,6 @@
 | log\_vault\_role | Name of the Vault role in the AWS secrets engine to provide credentials for fluentd to write to Elasticsearch and S3 | `string` | `"fluentd_logger"` | no |
 | logs\_cloudwatch\_enabled | Enable to log to CloudWatch | `bool` | `false` | no |
 | logs\_log\_group\_name | Name of CloudWatch Log Group to store logs | `string` | `"/fluentd/logs"` | no |
-| logs\_retention\_time | CloudWatch Log Retention Time | `number` | `90` | no |
 | logs\_s3\_abort\_incomplete\_days | Specifies the number of days after initiating a multipart upload when the multipart upload must be completed. | `number` | `7` | no |
 | logs\_s3\_bucket\_name | Name of S3 bucket to store logs for long term archival | `string` | `""` | no |
 | logs\_s3\_enabled | Enable to log to S3 | `bool` | `true` | no |

--- a/modules/fluentd/INOUT.md
+++ b/modules/fluentd/INOUT.md
@@ -24,13 +24,16 @@
 | fluentd\_cpu | CPU resource assigned to the fluentd job | `number` | `3000` | no |
 | fluentd\_force\_pull | Force pull an image. Useful if the tag is mutable. | `string` | `"false"` | no |
 | fluentd\_image | Docker image for fluentd | `string` | `"govtechsg/fluentd-s3-elasticsearch"` | no |
-| fluentd\_match | Tags that fluentd should output to S3 and Elasticsearch | `string` | `"@ERROR app.** docker.** services.** system.** vault**"` | no |
+| fluentd\_match | Tags that fluentd should output to S3, CloudWatch and Elasticsearch | `string` | `"@ERROR app.** docker.** services.** system.** vault**"` | no |
 | fluentd\_memory | Memory resource assigned to the fluentd job | `number` | `512` | no |
 | fluentd\_port | Port on the Docker image in which the TCP interface is exposed | `number` | `4224` | no |
 | fluentd\_tag | Tag for fluentd Docker image | `string` | `"1.2.5-latest"` | no |
 | inject\_source\_host | Inject the log source host name and address into the logs | `bool` | `true` | no |
 | log\_vault\_policy | Name of the Vault policy to allow creating AWS credentials to write to Elasticsearch and S3 | `string` | `"fluentd_logger"` | no |
 | log\_vault\_role | Name of the Vault role in the AWS secrets engine to provide credentials for fluentd to write to Elasticsearch and S3 | `string` | `"fluentd_logger"` | no |
+| logs\_cloudwatch\_enabled | Enable to log to CloudWatch | `bool` | `false` | no |
+| logs\_log\_group\_name | Name of CloudWatch Log Group to store logs | `string` | `"/fluentd/logs"` | no |
+| logs\_retention\_time | CloudWatch Log Retention Time | `number` | `90` | no |
 | logs\_s3\_abort\_incomplete\_days | Specifies the number of days after initiating a multipart upload when the multipart upload must be completed. | `number` | `7` | no |
 | logs\_s3\_bucket\_name | Name of S3 bucket to store logs for long term archival | `string` | `""` | no |
 | logs\_s3\_enabled | Enable to log to S3 | `bool` | `true` | no |

--- a/modules/fluentd/consul.tf
+++ b/modules/fluentd/consul.tf
@@ -3,6 +3,7 @@ locals {
   file_logging_consul_key         = "${var.consul_key_prefix}fluentd/log_to_file"
   fluentd_match_consul_key        = "${var.consul_key_prefix}fluentd/match"
   s3_consul_key                   = "${var.consul_key_prefix}fluentd/log_to_s3"
+  cloudwatch_consul_key           = "${var.consul_key_prefix}fluentd/log_to_cloudwatch"
   inject_source_host              = "${var.consul_key_prefix}fluentd/inject_source_host"
   source_address_key              = "${var.consul_key_prefix}fluentd/source_address_key"
   source_hostname_key             = "${var.consul_key_prefix}fluentd/source_hostname_key"
@@ -41,6 +42,14 @@ resource "consul_keys" "log_to_s3" {
   key {
     path   = local.s3_consul_key
     value  = var.logs_s3_enabled ? "true" : "false"
+    delete = true
+  }
+}
+
+resource "consul_keys" "log_to_cloudwatch" {
+  key {
+    path   = local.cloudwatch_consul_key
+    value  = var.logs_cloudwatch_enabled ? "true" : "false"
     delete = true
   }
 }

--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -20,6 +20,7 @@ data "template_file" "fluentd_tf_rendered_conf" {
     weekly_index_enabled_consul_key = local.weekly_index_enabled_consul_key
 
     log_group_name = var.logs_log_group_name
+    aws_region = var.aws_region
 
     inject_source_host  = local.inject_source_host
     source_address_key  = local.source_address_key

--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -20,7 +20,7 @@ data "template_file" "fluentd_tf_rendered_conf" {
     weekly_index_enabled_consul_key = local.weekly_index_enabled_consul_key
 
     log_group_name = var.logs_log_group_name
-    aws_region = var.aws_region
+    aws_region     = var.aws_region
 
     inject_source_host  = local.inject_source_host
     source_address_key  = local.source_address_key

--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -16,6 +16,7 @@ data "template_file" "fluentd_tf_rendered_conf" {
     file_logging_consul_key         = local.file_logging_consul_key
     fluentd_match_consul_key        = local.fluentd_match_consul_key
     s3_consul_key                   = local.s3_consul_key
+    cloudwatch_consul_key           = local.cloudwatch_consul_key
     weekly_index_enabled_consul_key = local.weekly_index_enabled_consul_key
 
     inject_source_host  = local.inject_source_host

--- a/modules/fluentd/main.tf
+++ b/modules/fluentd/main.tf
@@ -19,6 +19,8 @@ data "template_file" "fluentd_tf_rendered_conf" {
     cloudwatch_consul_key           = local.cloudwatch_consul_key
     weekly_index_enabled_consul_key = local.weekly_index_enabled_consul_key
 
+    log_group_name = var.logs_log_group_name
+
     inject_source_host  = local.inject_source_host
     source_address_key  = local.source_address_key
     source_hostname_key = local.source_hostname_key

--- a/modules/fluentd/s3.tf
+++ b/modules/fluentd/s3.tf
@@ -66,6 +66,28 @@ data "aws_iam_policy_document" "logs_s3" {
   }
 
   statement {
+    sid     = "AllowSSLRequestsOnly"
+    actions = ["s3:*"]
+    effect  = "Deny"
+
+    resources = [
+      aws_s3_bucket.logs[0].arn,
+      "${aws_s3_bucket.logs[0].arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = [false]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
     effect = "Allow"
 
     actions = [

--- a/modules/fluentd/s3.tf
+++ b/modules/fluentd/s3.tf
@@ -69,12 +69,12 @@ data "aws_iam_policy_document" "logs_s3" {
     effect = "Allow"
 
     actions = [
-        "logs:PutLogEvents",
-        "logs:CreateLogGroup",
-        "logs:PutRetentionPolicy",
-        "logs:CreateLogStream",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams"
+      "logs:PutLogEvents",
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy",
+      "logs:CreateLogStream",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
     ]
 
     resources = ["*"]

--- a/modules/fluentd/s3.tf
+++ b/modules/fluentd/s3.tf
@@ -66,28 +66,6 @@ data "aws_iam_policy_document" "logs_s3" {
   }
 
   statement {
-    sid     = "AllowSSLRequestsOnly"
-    actions = ["s3:*"]
-    effect  = "Deny"
-
-    resources = [
-      aws_s3_bucket.logs[0].arn,
-      "${aws_s3_bucket.logs[0].arn}/*",
-    ]
-
-    condition {
-      test     = "Bool"
-      variable = "aws:SecureTransport"
-      values   = [false]
-    }
-
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-  }
-
-  statement {
     effect = "Allow"
 
     actions = [

--- a/modules/fluentd/s3.tf
+++ b/modules/fluentd/s3.tf
@@ -64,6 +64,21 @@ data "aws_iam_policy_document" "logs_s3" {
       "${aws_s3_bucket.logs[0].arn}/*",
     ]
   }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+        "logs:PutLogEvents",
+        "logs:CreateLogGroup",
+        "logs:PutRetentionPolicy",
+        "logs:CreateLogStream",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+    ]
+
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "logs_s3" {

--- a/modules/fluentd/templates/fluent.conf
+++ b/modules/fluentd/templates/fluent.conf
@@ -17,8 +17,10 @@
   {{ if eq (keyOrDefault "${cloudwatch_consul_key}" "false") "true" }}
   <store {{ key "${fluentd_match_consul_key}" }}>
     @type cloudwatch_logs
+    region ${aws_region}
     log_group_name ${log_group_name}
-    log_stream_name "$${tag}"
+    use_tag_as_stream true
+    message_keys log
     auto_create_stream true
   </store>
   {{ end }}

--- a/modules/fluentd/templates/fluent.conf
+++ b/modules/fluentd/templates/fluent.conf
@@ -10,6 +10,15 @@
 @include /config/secrets/*.conf
 @include /config/additional/*.conf
 
+{{ if eq (keyOrDefault "${cloudwatch_consul_key}" "false") "true" }}
+<match {{ key "${fluentd_match_consul_key}" }}>
+  @type cloudwatch_logs
+  log_group_name ${log_group_name}
+  log_stream_name "$${tag}"
+  auto_create_stream true
+</match>
+{{ end }}
+
 <match {{ key "${fluentd_match_consul_key}" }}>
   @type copy
 

--- a/modules/fluentd/templates/fluent.conf
+++ b/modules/fluentd/templates/fluent.conf
@@ -10,17 +10,18 @@
 @include /config/secrets/*.conf
 @include /config/additional/*.conf
 
-{{ if eq (keyOrDefault "${cloudwatch_consul_key}" "false") "true" }}
-<match {{ key "${fluentd_match_consul_key}" }}>
-  @type cloudwatch_logs
-  log_group_name ${log_group_name}
-  log_stream_name "$${tag}"
-  auto_create_stream true
-</match>
-{{ end }}
 
 <match {{ key "${fluentd_match_consul_key}" }}>
   @type copy
+
+  {{ if eq (keyOrDefault "${cloudwatch_consul_key}" "false") "true" }}
+  <store {{ key "${fluentd_match_consul_key}" }}>
+    @type cloudwatch_logs
+    log_group_name ${log_group_name}
+    log_stream_name "$${tag}"
+    auto_create_stream true
+  </store>
+  {{ end }}
 
   {{ if eq (keyOrDefault "${file_logging_consul_key}" "false") "true" }}
   <store ignore_error>

--- a/modules/fluentd/variables.tf
+++ b/modules/fluentd/variables.tf
@@ -176,6 +176,25 @@ variable "tags" {
   }
 }
 
+#############################
+# CloudWatch Logging related
+#############################
+variable "logs_cloudwatch_enabled" {
+  description = "Enable to log to CloudWatch"
+  default     = false
+}
+
+variable "logs_log_group_name" {
+  description = "Name of CloudWatch Log Group to store logs"
+  default     = "/fluentd/logs"
+}
+
+variable "logs_retention_time" {
+  description = "CloudWatch Log Retention Time"
+  default     = 90
+}
+
+
 # --------------------------------------------------------------------------------------------------
 # CORE INTEGRATION SETTINGS
 # --------------------------------------------------------------------------------------------------
@@ -195,6 +214,6 @@ variable "enable_file_logging" {
 }
 
 variable "fluentd_match" {
-  description = "Tags that fluentd should output to S3 and Elasticsearch"
+  description = "Tags that fluentd should output to S3, CloudWatch and Elasticsearch"
   default     = "@ERROR app.** docker.** services.** system.** vault**"
 }

--- a/modules/fluentd/variables.tf
+++ b/modules/fluentd/variables.tf
@@ -184,6 +184,12 @@ variable "logs_cloudwatch_enabled" {
   default     = false
 }
 
+variable "logs_log_group_name" {
+  description = "Name of CloudWatch Log Group to store logs"
+  default     = "/fluentd/logs"
+}
+
+
 # --------------------------------------------------------------------------------------------------
 # CORE INTEGRATION SETTINGS
 # --------------------------------------------------------------------------------------------------

--- a/modules/fluentd/variables.tf
+++ b/modules/fluentd/variables.tf
@@ -184,17 +184,6 @@ variable "logs_cloudwatch_enabled" {
   default     = false
 }
 
-variable "logs_log_group_name" {
-  description = "Name of CloudWatch Log Group to store logs"
-  default     = "/fluentd/logs"
-}
-
-variable "logs_retention_time" {
-  description = "CloudWatch Log Retention Time"
-  default     = 90
-}
-
-
 # --------------------------------------------------------------------------------------------------
 # CORE INTEGRATION SETTINGS
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add support for CloudWatch Logging, besides S3 logging. CloudWatch logging requires S3 logging to also be enabled, since it also piggybacks on the S3 policies