### PR TITLE
feat(vault): remove configurable vault s3 bucket versioning

### DIFF
--- a/modules/vault-cluster/INOUT.md
+++ b/modules/vault-cluster/INOUT.md
@@ -29,7 +29,6 @@
 | enable\_auto\_unseal | (Vault Enterprise only) Emable auto unseal of the Vault cluster | `bool` | `false` | no |
 | enable\_dynamo\_backend | Whether to use a DynamoDB storage backend instead of Consul | `bool` | `false` | no |
 | enable\_s3\_backend | Whether to configure an S3 storage backend in addition to Consul. | `bool` | `false` | no |
-| enable\_s3\_bucket\_versioning | Whether to enable bucket versioning for the S3 bucket. | `bool` | `false` | no |
 | enabled\_metrics | List of autoscaling group metrics to enable. | `list(string)` | `[]` | no |
 | force\_destroy\_s3\_bucket | If 'configure\_s3\_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable\_s3\_backend' is set to true. | `bool` | `false` | no |
 | health\_check\_grace\_period | Time, in seconds, after instance comes into service before checking health. | `number` | `300` | no |

--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -287,10 +287,6 @@ resource "aws_s3_bucket" "vault_storage" {
     var.s3_bucket_tags,
   )
 
-  versioning {
-    enabled = var.enable_s3_bucket_versioning
-  }
-
   # aws_launch_configuration.launch_configuration in this module sets create_before_destroy to true, which means
   # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors
   # when you try to do a terraform destroy.

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -203,11 +203,6 @@ variable "s3_bucket_tags" {
   default     = {}
 }
 
-variable "enable_s3_bucket_versioning" {
-  description = "Whether to enable bucket versioning for the S3 bucket."
-  default     = false
-}
-
 variable "force_destroy_s3_bucket" {
   description = "If 'configure_s3_backend' is enabled and you set this to true, when you run terraform destroy, this tells Terraform to delete all the objects in the S3 bucket used for backend storage. You should NOT set this to true in production or you risk losing all your data! This property is only here so automated tests of this module can clean up after themselves. Only used if 'enable_s3_backend' is set to true."
   default     = false


### PR DESCRIPTION
Context:
- the current vault s3 bucket versioning is configurable from the `vault-cluster` module but can not be passed in from the `core` parent module, thus not from the grandparent module, i.e. `l-cloud-gcc` `core` module. This makes it almost useless.
- there is another logs s3 bucket in the `fluentd` module which comes with default versioning config, i.e. no versioning config (default to false).

Description:
- this helper package should come with default config. Customized configuration can be done at the parent, i.e. `l-cloud-gcc` for maintainability so that all configs for the buckets are in 1 place
- this sync with the logs s3 bucket in the `fluentd` module
