### PR TITLE
fix(vapt-scr): use python built-in func

### DIFF
--- a/modules/core/upgrade.py
+++ b/modules/core/upgrade.py
@@ -458,7 +458,7 @@ def upgrade_vault(tag_pattern, consul_addr, service_name, vault_port, tls_server
 
     unseal_keys = set()
     for _ in range(0, unseal_count):
-        unseal_keys.add(sys.stdin.readline().strip())
+        unseal_keys.add(input().strip())
 
     assert_collection_len(unseal_keys, unseal_count)
 


### PR DESCRIPTION
## Stories
- stored command injection - https://www.notion.so/aipf-locus/Stored-Command-Injection-1-item-1134e47c1d8780bba157decd946100d9?pvs=4
- stored command argument injection - https://www.notion.so/aipf-locus/Stored-Command-Argument-Injection-1-item-1134e47c1d87807c914cc11c8007969b?pvs=4

## Motivation & Context
- Flagged out in VAPT source scan as:
  - medium severity finding (stored command injection)
  - low severity finding (stored command argument injection)

## Description
- Same offending code for both findings `sys.stdin.readline()`

## Implication
- stored command injection
  - The application runs an OS system-level command to complete it's task, rather than via the application code. The command includes untrusted data, that may be controllable by an attacker. This untrusted string may contain malicious system-level commands engineered by an attacker, which could be executed as though the attacker were running commands directly on the application server.In this case, the application reads the command from the database, and passes it as a string to the Operating System. The attacker may be able to load the malicious payload into the database fields beforehand, causing the application to load that command. This unvalidated data is then executed by the OS as a system command, running with the same system privileges as the application.
- stored command argument injection
  - A potentially tainted value is passed as an argument to an external program, which is executed by code.

## Recommendation
- Same recommendation for both findings
  - Refactor the code to avoid any direct shell command execution. Instead, use platform provided APIs or library calls.
  - If it is impossible to remove the command execution, execute only static commands that do not include dynamic, user-controlled data.
  - Validate all input, regardless of source. Validation should be based on a whitelist: accept only data fitting a specified format, rather than rejecting bad patterns (blacklist). Parameters should be limited to an allowed character set, and non-validated input should be dropped. In addition to characters, check for:
    - Data type
    - Size
    - Range
    - Format
    - Expected values
  - In order to minimize damage as a measure of defense in depth, configure the application to run using a restricted user account that has no unnecessary OS privileges.
  - If possible, isolate all OS commands to use a separate dedicated user account that has minimal privileges only for the specific commands and files used by the application, according to the Principle of Least Privilege.

## Implemented Fix
- as recommended, avoid direct shell command execution. Use python built-in `input()` function instead

## How has this been tested?
